### PR TITLE
Resolve model and data paths relative to source directory

### DIFF
--- a/face/agent.py
+++ b/face/agent.py
@@ -10,6 +10,7 @@ Can be run standalone with face_tracker + voice_input + voice_output:
     python agent.py [--no-voice] [--no-auto-ask]
 """
 
+import os
 import time
 import threading
 import logging
@@ -31,6 +32,7 @@ from llm import ConversationLLM, get_goodbye
 
 logger = logging.getLogger("agent")
 
+_SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 # ---------------------------------------------------------------------------
 # Agent event types
@@ -764,8 +766,8 @@ def _draw_echo_state(frame, agent):
 
 def main():
     parser = argparse.ArgumentParser(description="Standalone agent")
-    parser.add_argument("--db-dir", default="known_faces")
-    parser.add_argument("--people-dir", default="people")
+    parser.add_argument("--db-dir", default=os.path.join(_SOURCE_DIR, "known_faces"))
+    parser.add_argument("--people-dir", default=os.path.join(_SOURCE_DIR, "people"))
     parser.add_argument("--camera", type=int, default=0)
     parser.add_argument("--fps", type=int, default=15)
     parser.add_argument("--no-auto-ask", action="store_true")
@@ -961,7 +963,7 @@ def main():
         pass
 
     # Force-exit on second Ctrl+C if cleanup hangs
-    import signal, os
+    import signal
     signal.signal(signal.SIGINT, lambda *_: os._exit(1))
 
     print("\nShutting down...")

--- a/face/download_models.py
+++ b/face/download_models.py
@@ -5,7 +5,8 @@ import os
 import sys
 import urllib.request
 
-PIPER_MODEL_DIR = "piper_models"
+_SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+PIPER_MODEL_DIR = os.path.join(_SOURCE_DIR, "piper_models")
 
 
 def _load_models_from_config() -> dict[str, str]:

--- a/face/face_tracker.py
+++ b/face/face_tracker.py
@@ -37,7 +37,10 @@ from events import EventDispatcher
 
 logger = logging.getLogger("face_tracker")
 
-EMOTION_MODEL_DIR = "emotion_model"
+_SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+EMOTION_MODEL_DIR = os.path.join(_SOURCE_DIR, "emotion_model")
+_KNOWN_FACES_DIR = os.path.join(_SOURCE_DIR, "known_faces")
 EMOTION_MODEL_URL = "https://github.com/onnx/models/raw/main/validated/vision/body_analysis/emotion_ferplus/model/emotion-ferplus-8.onnx"
 EMOTION_LABELS = ["neutral", "happy", "surprise", "sad", "angry", "disgust", "fear", "contempt"]
 
@@ -203,7 +206,7 @@ class FaceDatabase:
 
     SCHEMA_VERSION = 2
 
-    def __init__(self, db_dir: str = "known_faces", tolerance: float = 0.6):
+    def __init__(self, db_dir: str = _KNOWN_FACES_DIR, tolerance: float = 0.6):
         self.db_dir = db_dir
         self.tolerance = tolerance
         self._db = {

--- a/face/main.py
+++ b/face/main.py
@@ -28,7 +28,9 @@ from llm import ConversationLLM
 # Logging
 # ---------------------------------------------------------------------------
 
-LOG_DIR = "logs"
+_SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+LOG_DIR = os.path.join(_SOURCE_DIR, "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 LOG_FILE = os.path.join(LOG_DIR, f"face_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log")
 
@@ -328,8 +330,8 @@ def draw_faces(frame, tracker, memory):
 
 def main():
     parser = argparse.ArgumentParser(description="Face Agent UI")
-    parser.add_argument("--db-dir", default="known_faces")
-    parser.add_argument("--people-dir", default="people")
+    parser.add_argument("--db-dir", default=os.path.join(_SOURCE_DIR, "known_faces"))
+    parser.add_argument("--people-dir", default=os.path.join(_SOURCE_DIR, "people"))
     parser.add_argument("--camera", type=int, default=0)
     parser.add_argument("--fps", type=int, default=15)
     parser.add_argument("--no-auto-ask", action="store_true")

--- a/face/people_memory.py
+++ b/face/people_memory.py
@@ -164,7 +164,11 @@ class PeopleMemory:
     the JSON and can be changed freely without touching the ID.
     """
 
-    def __init__(self, storage_dir: str = "people"):
+    _DEFAULT_DIR = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "people"
+    )
+
+    def __init__(self, storage_dir: str = _DEFAULT_DIR):
         self._dir = storage_dir
         # Active session: track_id -> Person
         self._active: dict[int, Person] = {}

--- a/face/voice_output.py
+++ b/face/voice_output.py
@@ -29,7 +29,9 @@ from events import EventDispatcher
 
 logger = logging.getLogger("voice_output")
 
-PIPER_MODEL_DIR = "piper_models"
+_SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+PIPER_MODEL_DIR = os.path.join(_SOURCE_DIR, "piper_models")
 PIPER_MODEL_NAME = "en_US-lessac-medium"
 
 # Language models loaded from languages.toml (with hardcoded fallback)


### PR DESCRIPTION
Default paths for models (piper_models, emotion_model), data (known_faces, people), and logs were relative to the current working directory, breaking when modules are used from other directories. Now all defaults resolve relative to the source file location.