### PR TITLE
Standardize all components to require Python >=3.13

### DIFF
--- a/candytron_mcp/pyproject.toml
+++ b/candytron_mcp/pyproject.toml
@@ -3,7 +3,7 @@ name = "candytron_mcp"
 version = "0.1.0"
 description = "Candytron 4000, as an MCP service"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "pyniryo",
     "pyyaml",

--- a/dirigera/fastmcp/pyproject.toml
+++ b/dirigera/fastmcp/pyproject.toml
@@ -3,7 +3,7 @@ name = "dirgera-mcp"
 version = "0.1.0"
 description = "Dirigera MCP Server for IoT control"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 
 dependencies = [
     "dirigera>=1.2.2",

--- a/face/pyproject.toml
+++ b/face/pyproject.toml
@@ -2,7 +2,7 @@
 name = "face-agent"
 version = "0.1.0"
 description = "Face recognition app that learns faces over time"
-requires-python = ">=3.11,<3.13"
+requires-python = ">=3.13"
 
 dependencies = [
     "dlib",

--- a/githubmcp/pyproject.toml
+++ b/githubmcp/pyproject.toml
@@ -3,7 +3,7 @@ name = "githubmcp"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=2.3.4",
     "requests>=2.32.3",

--- a/mcpclient_speech/pyproject.toml
+++ b/mcpclient_speech/pyproject.toml
@@ -3,7 +3,7 @@ name = "mcpscreen"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "openai",
     "fastmcp>=2.3.4",

--- a/mcpclient_text/pyproject.toml
+++ b/mcpclient_text/pyproject.toml
@@ -3,7 +3,7 @@ name = "mcpclient_text"
 version = "0.1.0"
 description = "Generic LLM-based MCP-client"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "openai",
     "fastmcp>=2.3.4",

--- a/mcpscreen/pyproject.toml
+++ b/mcpscreen/pyproject.toml
@@ -3,7 +3,7 @@ name = "mcpscreen"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=2.3.4",
     "mss>=10.0.0",

--- a/mcpwebcam/pyproject.toml
+++ b/mcpwebcam/pyproject.toml
@@ -3,7 +3,7 @@ name = "mcpscreen"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=2.3.4",
     "ollama>=0.4.8",

--- a/xledplus_mcp/pyproject.toml
+++ b/xledplus_mcp/pyproject.toml
@@ -3,7 +3,7 @@ name = "xledplus_mcp"
 version = "0.1.0"
 description = "An MCP-server to control a Twinkly LED light string."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=2.3.4",
     "xled_plus",


### PR DESCRIPTION
Python 3.13 via uv bundles tkinter on macOS, which is needed by mcpclient_speech. Aligning all components to the same version simplifies cross-component imports.