### PR TITLE
Demo control: speech client config, face client polish, candytron CPU fix

### DIFF
--- a/candytron_mcp/README.md
+++ b/candytron_mcp/README.md
@@ -13,17 +13,18 @@ Then you can can use it by starting a generic MCP client such as mcpclient_speec
 ## Scene logging
 
 Pass `--log-scenes-dir DIR` to record every scene request from a connected
-client. For each call to the `get_service_augmentation` prompt, two files are
-written into `DIR`:
+client. For each call to the `get_service_augmentation` prompt, three files
+are written into `DIR`:
 
 - `<timestamp>.jpg` — the most recent annotated camera frame (with YOLO
   bounding boxes and labels), the same picture shown in the OpenCV window.
+- `<timestamp>_raw.jpg` — the corresponding unannotated camera frame.
 - `<timestamp>.json` — the state returned to the caller, containing
   `timestamp`, `lang`, `scene` (the consensus dict of position → candy) and
   `message` (the formatted string the caller receives).
 
 The flag is opt-in. When unset, no extra I/O is performed. In simulated camera
-mode no JPG is produced (there is no real frame), but the JSON is still
+mode no JPGs are produced (there is no real frame), but the JSON is still
 written.
 
 ```bash

--- a/candytron_mcp/README.md
+++ b/candytron_mcp/README.md
@@ -10,3 +10,22 @@ uv run candytron_mcp.py
 
 Then you can can use it by starting a generic MCP client such as mcpclient_speech or mcpclient_text.
 
+## Scene logging
+
+Pass `--log-scenes-dir DIR` to record every scene request from a connected
+client. For each call to the `get_service_augmentation` prompt, two files are
+written into `DIR`:
+
+- `<timestamp>.jpg` — the most recent annotated camera frame (with YOLO
+  bounding boxes and labels), the same picture shown in the OpenCV window.
+- `<timestamp>.json` — the state returned to the caller, containing
+  `timestamp`, `lang`, `scene` (the consensus dict of position → candy) and
+  `message` (the formatted string the caller receives).
+
+The flag is opt-in. When unset, no extra I/O is performed. In simulated camera
+mode no JPG is produced (there is no real frame), but the JSON is still
+written.
+
+```bash
+uv run candytron_mcp.py --log-scenes-dir ./scene-log
+```

--- a/candytron_mcp/camera.py
+++ b/candytron_mcp/camera.py
@@ -1,6 +1,7 @@
 import cv2
 import logging
 import os
+import time
 from ultralytics import YOLO
 
 logger = logging.getLogger("candytron.camera")
@@ -114,9 +115,16 @@ class CameraManager:
                  (bx.xyxy[0][0] + bx.xyxy[0][2]) / 2,
                  (bx.xyxy[0][1] + bx.xyxy[0][3]) / 2) for bx in res.boxes]
 
-    def check_event(self, wait_ms: int = 1) -> bool:
+    def check_event(self, wait_ms: int = 50) -> bool:
+        """Pump the GUI event loop and pace the caller.
+
+        Always sleeps ``wait_ms`` ms (via ``cv2.waitKey`` when a window is
+        shown, otherwise ``time.sleep``). Returns True if the user pressed 'q'.
+        """
         if self.has_camera() and self.show_window:
             return cv2.waitKey(wait_ms) & 0xFF == ord('q')
+        if wait_ms > 0:
+            time.sleep(wait_ms / 1000.0)
         return False
 
     def calibrate_positions(self, n: int, m: int) -> bool:

--- a/candytron_mcp/camera.py
+++ b/candytron_mcp/camera.py
@@ -38,6 +38,7 @@ class CameraManager:
         self.positions_thresdist: float = 0
         self._open_window_count: int = 0
         self._last_frame = None
+        self._last_raw_frame = None
         self._last_frame_lock = threading.Lock()
 
     @staticmethod
@@ -91,11 +92,18 @@ class CameraManager:
         return self.yolomodel is not None
 
     def get_last_frame(self):
-        """Return a copy of the most recent camera frame, or None if unavailable."""
+        """Return a copy of the most recent annotated camera frame, or None if unavailable."""
         with self._last_frame_lock:
             if self._last_frame is None:
                 return None
             return self._last_frame.copy()
+
+    def get_last_raw_frame(self):
+        """Return a copy of the most recent raw camera frame, or None if unavailable."""
+        with self._last_frame_lock:
+            if self._last_raw_frame is None:
+                return None
+            return self._last_raw_frame.copy()
 
     def acquire_scene_one(self, refresh: bool = False) -> list[tuple]:
         if not self.has_camera():
@@ -113,6 +121,7 @@ class CameraManager:
         annotated_frame = res.plot()
         with self._last_frame_lock:
             self._last_frame = annotated_frame
+            self._last_raw_frame = fr
 
         if self.show_window:
             h, w = annotated_frame.shape[:2]

--- a/candytron_mcp/camera.py
+++ b/candytron_mcp/camera.py
@@ -1,6 +1,7 @@
 import cv2
 import logging
 import os
+import threading
 import time
 from ultralytics import YOLO
 
@@ -36,6 +37,8 @@ class CameraManager:
         self.positions: dict[str, tuple] = {}
         self.positions_thresdist: float = 0
         self._open_window_count: int = 0
+        self._last_frame = None
+        self._last_frame_lock = threading.Lock()
 
     @staticmethod
     def list_cameras(max_index: int = 10) -> list[dict]:
@@ -87,6 +90,13 @@ class CameraManager:
     def has_camera(self) -> bool:
         return self.yolomodel is not None
 
+    def get_last_frame(self):
+        """Return a copy of the most recent camera frame, or None if unavailable."""
+        with self._last_frame_lock:
+            if self._last_frame is None:
+                return None
+            return self._last_frame.copy()
+
     def acquire_scene_one(self, refresh: bool = False) -> list[tuple]:
         if not self.has_camera():
             return list(_SIMULATED_DETECTIONS)
@@ -100,13 +110,16 @@ class CameraManager:
             logger.error("Failed to read frame from camera")
             return []
         res = self.yolomodel(fr, verbose=False)[0]
+        annotated_frame = res.plot()
+        with self._last_frame_lock:
+            self._last_frame = annotated_frame
 
         if self.show_window:
-            annotated_frame = res.plot()
             h, w = annotated_frame.shape[:2]
+            display_frame = annotated_frame
             if w > 1280:
-                annotated_frame = cv2.resize(annotated_frame, (w // 2, h // 2))
-            cv2.imshow('YOLO Detection', annotated_frame)
+                display_frame = cv2.resize(annotated_frame, (w // 2, h // 2))
+            cv2.imshow('YOLO Detection', display_frame)
             if self._open_window_count == 0:
                 cv2.moveWindow('YOLO Detection', 200, 50)
             self._open_window_count += 1

--- a/candytron_mcp/candytron_mcp.py
+++ b/candytron_mcp/candytron_mcp.py
@@ -12,6 +12,7 @@ from camera import CameraManager
 from robotarm import init_ned, exit_ned, ned_move_between
 from transtable import transhead, transtable
 from scene_state import SceneState
+from scene_logger import SceneLogger
 
 logger = logging.getLogger("candytron")
 
@@ -19,6 +20,7 @@ mcp = FastMCP("Candytron 4000")
 
 cam: CameraManager | None = None
 scene_state = SceneState()
+scene_logger: SceneLogger | None = None
 use_robot = True
 
 @mcp.resource("url://get_service_name")
@@ -71,7 +73,11 @@ def scene_message(scene, lang):
 def get_service_augmentation(lang: str) -> str:
     """Return extra information on the current state, to insert before the user prompt"""
     scene = scene_state.get_scene()
-    return scene_message(scene, lang)
+    message = scene_message(scene, lang)
+    if scene_logger is not None:
+        frame = cam.get_last_frame() if cam else None
+        scene_logger.log(scene, frame, lang, message)
+    return message
 
 @mcp.tool()
 def show_demo_move() -> str:
@@ -116,7 +122,7 @@ def _run_mcp_server(args):
 
 
 def main():
-    global use_robot, cam
+    global use_robot, cam, scene_logger
 
     parser = argparse.ArgumentParser(description=mcp.name)
     parser.add_argument('--host', default="127.0.0.1", help='Host to bind to')
@@ -127,6 +133,7 @@ def main():
     parser.add_argument('-l', '--list-cameras', action='store_true', help='List available cameras and exit')
     parser.add_argument('--camera', type=int, default=None, help='Camera index to use (default: auto-detect first available)')
     parser.add_argument('--no-window', action='store_true', help='Disable the OpenCV display window')
+    parser.add_argument('--log-scenes-dir', default=None, help='If set, log every scene request (annotated camera frame + returned state) to this directory')
     parser.add_argument('-v', '--verbose', action='count', default=0, help='Increase verbosity (-v for INFO, -vv for DEBUG)')
     args = parser.parse_args()
 
@@ -140,6 +147,11 @@ def main():
         level=log_level,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
+
+    # Enable scene-request logging if requested
+    if args.log_scenes_dir:
+        scene_logger = SceneLogger(args.log_scenes_dir)
+        logger.info("Scene-request logging enabled at %s", args.log_scenes_dir)
 
     # List cameras and exit
     if args.list_cameras:

--- a/candytron_mcp/candytron_mcp.py
+++ b/candytron_mcp/candytron_mcp.py
@@ -76,7 +76,8 @@ def get_service_augmentation(lang: str) -> str:
     message = scene_message(scene, lang)
     if scene_logger is not None:
         frame = cam.get_last_frame() if cam else None
-        scene_logger.log(scene, frame, lang, message)
+        raw_frame = cam.get_last_raw_frame() if cam else None
+        scene_logger.log(scene, frame, raw_frame, lang, message)
     return message
 
 @mcp.tool()

--- a/candytron_mcp/scene_logger.py
+++ b/candytron_mcp/scene_logger.py
@@ -9,13 +9,14 @@ logger = logging.getLogger("candytron.scene_logger")
 
 
 class SceneLogger:
-    """Persist scene-request snapshots: paired <timestamp>.jpg / <timestamp>.json."""
+    """Persist scene-request snapshots: <timestamp>.jpg (annotated),
+    <timestamp>_raw.jpg (raw), and <timestamp>.json (state)."""
 
     def __init__(self, directory: str):
         self.directory = directory
         os.makedirs(self.directory, exist_ok=True)
 
-    def log(self, scene: dict[str, str], frame, lang: str, message: str) -> None:
+    def log(self, scene: dict[str, str], frame, raw_frame, lang: str, message: str) -> None:
         try:
             now = datetime.now(timezone.utc)
             prefix = now.strftime("%Y%m%dT%H%M%S_%f") + "Z"
@@ -25,6 +26,11 @@ class SceneLogger:
                 jpg_path = base + ".jpg"
                 if not cv2.imwrite(jpg_path, frame):
                     logger.warning("cv2.imwrite returned False for %s", jpg_path)
+
+            if raw_frame is not None:
+                raw_path = base + "_raw.jpg"
+                if not cv2.imwrite(raw_path, raw_frame):
+                    logger.warning("cv2.imwrite returned False for %s", raw_path)
 
             payload = {
                 "timestamp": now.isoformat(),

--- a/candytron_mcp/scene_logger.py
+++ b/candytron_mcp/scene_logger.py
@@ -1,0 +1,38 @@
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import cv2
+
+logger = logging.getLogger("candytron.scene_logger")
+
+
+class SceneLogger:
+    """Persist scene-request snapshots: paired <timestamp>.jpg / <timestamp>.json."""
+
+    def __init__(self, directory: str):
+        self.directory = directory
+        os.makedirs(self.directory, exist_ok=True)
+
+    def log(self, scene: dict[str, str], frame, lang: str, message: str) -> None:
+        try:
+            now = datetime.now(timezone.utc)
+            prefix = now.strftime("%Y%m%dT%H%M%S_%f") + "Z"
+            base = os.path.join(self.directory, prefix)
+
+            if frame is not None:
+                jpg_path = base + ".jpg"
+                if not cv2.imwrite(jpg_path, frame):
+                    logger.warning("cv2.imwrite returned False for %s", jpg_path)
+
+            payload = {
+                "timestamp": now.isoformat(),
+                "lang": lang,
+                "scene": scene,
+                "message": message,
+            }
+            with open(base + ".json", "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+        except Exception:
+            logger.warning("Failed to log scene request", exc_info=True)

--- a/face/voice_input.py
+++ b/face/voice_input.py
@@ -487,6 +487,7 @@ class VoiceInput:
         self.vad_prob: float = 0.0
         self.listen_phase: str = ""  # "", "waiting", "recording", "transcribing"
         self._cancel_listen: bool = False
+        self._flush_listen: bool = False
         self.detected_language: str = ""
         self.detected_language_prob: float = 0.0
 
@@ -573,6 +574,12 @@ class VoiceInput:
 
     # --- Core operations ---
 
+    def flush_listen(self) -> None:
+        """Stop a VAD-driven listen() in progress and proceed to transcribe
+        whatever speech has been captured so far. If no speech has started
+        yet, this is equivalent to cancelling. Safe to call from any thread."""
+        self._flush_listen = True
+
     def listen(self, seconds: int = None, on_segment: Callable = None) -> Optional[str]:
         """Blocking STT. Tries VAD, falls back to fixed recording.
         Returns transcribed text or None."""
@@ -602,6 +609,7 @@ class VoiceInput:
         self.listen_phase = "waiting"
         self.vad_prob = 0.0
         self._cancel_listen = False
+        self._flush_listen = False
 
         vad_model = self._vad_model
         vad_model.reset_states()
@@ -630,6 +638,12 @@ class VoiceInput:
             while True:
                 if self._cancel_listen:
                     logger.info("[VAD] listen cancelled")
+                    return None
+                if self._flush_listen:
+                    if speech_started:
+                        logger.info("[VAD] listen flushed; transcribing captured audio")
+                        break
+                    logger.info("[VAD] listen flushed before speech detected; nothing to transcribe")
                     return None
 
                 data, _ = stream.read(chunk_samples)

--- a/face/voice_input.py
+++ b/face/voice_input.py
@@ -65,6 +65,7 @@ class VoiceEventType(Enum):
     TRANSCRIPTION_COMPLETE = auto()
     TRANSCRIPTION_EMPTY = auto()
     LISTEN_FAILED = auto()
+    RECORDING_SAVED = auto()
 
     # Continuous listener
     CONTINUOUS_STARTED = auto()
@@ -146,6 +147,12 @@ class ListenFailedPayload:
 
 
 @dataclass(frozen=True)
+class RecordingSavedPayload:
+    path: str
+    remaining: int
+
+
+@dataclass(frozen=True)
 class ContinuousStatePayload:
     pass
 
@@ -156,7 +163,7 @@ VoiceEventPayload = Union[
     RecordingStartedPayload, TranscriptionStartedPayload,
     TranscriptionSegmentPayload, TranscriptionCompletePayload,
     TranscriptionEmptyPayload, ListenFailedPayload,
-    ContinuousStatePayload,
+    RecordingSavedPayload, ContinuousStatePayload,
 ]
 
 
@@ -488,6 +495,8 @@ class VoiceInput:
         self.listen_phase: str = ""  # "", "waiting", "recording", "transcribing"
         self._cancel_listen: bool = False
         self._flush_listen: bool = False
+        self._save_next_count: int = 0
+        self._save_dir: str = "recordings"
         self.detected_language: str = ""
         self.detected_language_prob: float = 0.0
 
@@ -579,6 +588,31 @@ class VoiceInput:
         whatever speech has been captured so far. If no speech has started
         yet, this is equivalent to cancelling. Safe to call from any thread."""
         self._flush_listen = True
+
+    def save_next_recordings(self, n: int = 1, directory: Optional[str] = None) -> int:
+        """Arm the next N completed VAD recordings for saving to WAV files
+        in `directory` (default: 'recordings' under the working directory).
+        Each saved recording decrements the counter and emits a
+        RECORDING_SAVED event. Returns the new pending count."""
+        if directory:
+            self._save_dir = directory
+        self._save_next_count += int(n)
+        return self._save_next_count
+
+    def _save_recording(self, audio: np.ndarray) -> str:
+        import wave
+        os.makedirs(self._save_dir, exist_ok=True)
+        ms = int(time.time() * 1000) % 1000
+        fname = f"recording_{time.strftime('%Y%m%d_%H%M%S')}_{ms:03d}.wav"
+        path = os.path.join(self._save_dir, fname)
+        pcm16 = np.clip(audio * 32767.0, -32768, 32767).astype(np.int16)
+        with wave.open(path, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(self._sample_rate)
+            wf.writeframes(pcm16.tobytes())
+        logger.info(f"Saved recording to {path}")
+        return path
 
     def listen(self, seconds: int = None, on_segment: Callable = None) -> Optional[str]:
         """Blocking STT. Tries VAD, falls back to fixed recording.
@@ -703,6 +737,16 @@ class VoiceInput:
         self.vad_prob = 0.0
         audio = np.concatenate(speech_chunks)
         audio_duration_ms = int(len(audio) / self._sample_rate * 1000)
+
+        if self._save_next_count > 0:
+            try:
+                saved_path = self._save_recording(audio)
+            except Exception as e:
+                logger.warning(f"Failed to save recording: {e}")
+            else:
+                self._save_next_count -= 1
+                self._emit(VoiceEventType.RECORDING_SAVED,
+                           RecordingSavedPayload(saved_path, self._save_next_count))
 
         noise_reduced = False
         if self._noise_reduce:

--- a/mcpclient_speech/README.md
+++ b/mcpclient_speech/README.md
@@ -77,6 +77,7 @@ The MCP server must already be running on SSE before the client starts.
 | Ctrl     | Hold to record         | —                                   |
 | Space    | Stop recording, send   | Stop listening, transcribe captured audio |
 | `m`      | —                      | Toggle mute (mic + TTS)             |
+| `s`      | —                      | Arm next recording for saving (press N times for N saves) |
 | `c`      | Clear conversation     | —                                   |
 | `r`      | Repeat last response   | —                                   |
 | `q`      | Quit                   | Quit                                |
@@ -85,6 +86,13 @@ Pressing space in the face client while VAD is stuck on background
 noise will flush the captured speech to Whisper instead of discarding
 it; the LLM responds as usual. Mute (`m`) immediately silences the
 microphone *and* aborts any TTS playback in progress.
+
+Pressing `s` in the face client arms the next VAD recording for
+saving as a 16-bit mono WAV under `recordings/` (auto-created). Press
+it N times to queue N saves. The pending count is shown in the top-left
+corner of the window ("Save next 3"); each saved recording decrements
+the counter. Recordings are written before noise reduction so the file
+contains the raw mic audio.
 
 ## Tips
 

--- a/mcpclient_speech/README.md
+++ b/mcpclient_speech/README.md
@@ -1,19 +1,96 @@
-# Generic speech-to-speech LLM-based MCP-client
-A generic MCP-client which can connect to any Fastmcp server and then provides access to its tools via speech-based communication with an LLM.
+# Generic speech-to-speech LLM-based MCP client
 
-### Prerequisites
+An MCP client that connects to any FastMCP server (over SSE) and exposes
+its tools through voice interaction with a local LLM. Two variants:
 
-You need to have Ollama installed, and to have downloaded a suitable LLM model.
-Near the top of mcpclient_speech.py you can insert the correct model name.
+- **`mcpclient_speech.py`** — push-to-talk. Hold Ctrl (or click the eye)
+  to record, release to send.
+- **`mcpclient_speech_face.py`** — face-triggered, continuous. A camera
+  detects when someone is in focus and the system listens until VAD
+  closes. Maintains per-person memory (name, language, preferences).
 
-You also need to install whisper.cpp and piper. Near the top of record.py is a path to the whisper.cpp directory which may be adjusted. In piperscript are the paths to piper and the piper models. Right now the code assumes that there are available piper voices for languages en, sv, de, fr, and es.
+## Prerequisites
 
-Before running this client, you need to start a selected MCP-server, with the tools to control some gadget. See its README for how.
+- **Ollama** with a tool-capable model pulled (default
+  `PetrosStav/gemma3-tools:12b`).
+- **whisper.cpp** built locally — used by `record.py` for STT in the
+  push-to-talk client. Path is hardcoded at the top of `record.py`
+  (`whisperdir`); model is `ggml-medium.bin`.
+- **piper** with voices for `en`, `sv`, `de`, `fr`, `es`. Paths are in
+  `piperscript`.
+- **`../face/`** sibling directory — the face client imports
+  `VoiceInput`, `VoiceOutput`, `FaceTracker` from there.
+- A running FastMCP server on SSE (default `http://127.0.0.1:8000/sse`).
 
-### Run the server through this client 
+## Configuration
 
-Start this client like this, and then you can start chatting with your gadget.
-```bash
-uv run mcpclient_text.py
+Settings are read from `config.toml` (next to the scripts) on startup;
+CLI arguments override anything in the config, and the config overrides
+the built-in defaults in `config.py`. Sections:
+
+```toml
+[llm]
+model    = "PetrosStav/gemma3-tools:12b"
+base_url = "http://localhost:11434/v1/"
+api_key  = "ollama"
+
+[face]
+omit_names_and_prefs = false   # set true to skip name/preference distillation
+
+[devices]
+# microphone = 5   # PyAudio / sounddevice device index
+# camera     = 0   # face client only
 ```
 
+Use `--config <path>` to load a different file.
+
+Unknown sections or keys produce a warning on stderr and are ignored.
+
+## Running
+
+```bash
+# Push-to-talk
+uv run python mcpclient_speech.py [--config path]
+
+# Face-tracking
+uv run python mcpclient_speech_face.py \
+    [--config path] [--server URL] \
+    [--camera N] [--mic N] \
+    [--llm-model MODEL] [--llm-url URL] [-v|-vv]
+
+# List available microphones / cameras
+python hardware_devices.py -m            # microphones
+python hardware_devices.py -c            # cameras
+uv run python mcpclient_speech_face.py -m   # built into face client
+uv run python mcpclient_speech_face.py -l   # list cameras
+
+# Start the candytron MCP server + face client together (tmux)
+./start-candytron.sh
+```
+
+The MCP server must already be running on SSE before the client starts.
+
+## Keyboard shortcuts (window must be focused)
+
+| Key      | Push-to-talk           | Face client                         |
+| -------- | ---------------------- | ----------------------------------- |
+| Ctrl     | Hold to record         | —                                   |
+| Space    | Stop recording, send   | Stop listening, transcribe captured audio |
+| `m`      | —                      | Toggle mute (mic + TTS)             |
+| `c`      | Clear conversation     | —                                   |
+| `r`      | Repeat last response   | —                                   |
+| `q`      | Quit                   | Quit                                |
+
+Pressing space in the face client while VAD is stuck on background
+noise will flush the captured speech to Whisper instead of discarding
+it; the LLM responds as usual. Mute (`m`) immediately silences the
+microphone *and* aborts any TTS playback in progress.
+
+## Tips
+
+- **Background noise**: the face client uses VAD to decide when speech
+  ends. Loud or constant background noise (fans, music, a busy room)
+  can keep VAD open indefinitely, so the system never moves on to
+  process what was said. Lowering the microphone input level in your
+  operating system's audio settings usually fixes this. Press space to
+  force the captured audio through immediately.

--- a/mcpclient_speech/config.py
+++ b/mcpclient_speech/config.py
@@ -1,0 +1,24 @@
+import tomllib
+from pathlib import Path
+
+_DEFAULTS: dict = {
+    "llm": {
+        "model": "PetrosStav/gemma3-tools:12b",
+        "base_url": "http://localhost:11434/v1/",
+        "api_key": "ollama",
+    },
+    "behavior": {
+        "omit_names_and_prefs": False,
+    },
+    "devices": {},
+}
+
+def load_config(path: str | Path | None = None) -> dict:
+    cfg = {k: dict(v) for k, v in _DEFAULTS.items()}
+    if path is None:
+        path = Path(__file__).parent / "config.toml"
+    if Path(path).exists():
+        with open(path, "rb") as f:
+            for section, values in tomllib.load(f).items():
+                cfg.setdefault(section, {}).update(values)
+    return cfg

--- a/mcpclient_speech/config.py
+++ b/mcpclient_speech/config.py
@@ -1,3 +1,4 @@
+import sys
 import tomllib
 from pathlib import Path
 
@@ -10,15 +11,35 @@ _DEFAULTS: dict = {
     "face": {
         "omit_names_and_prefs": False,
     },
-    "devices": {},
+    "devices": {
+        "microphone": None,
+        "camera": None,
+    },
 }
+
+
+def _warn(msg: str) -> None:
+    print(f"config: {msg}", file=sys.stderr)
+
 
 def load_config(path: str | Path | None = None) -> dict:
     cfg = {k: dict(v) for k, v in _DEFAULTS.items()}
     if path is None:
         path = Path(__file__).parent / "config.toml"
-    if Path(path).exists():
-        with open(path, "rb") as f:
-            for section, values in tomllib.load(f).items():
-                cfg.setdefault(section, {}).update(values)
+    path = Path(path)
+    if not path.exists():
+        return cfg
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    for section, values in data.items():
+        if section not in _DEFAULTS:
+            _warn(f"unknown section [{section}] in {path}; ignored")
+            continue
+        valid = {}
+        for key, val in values.items():
+            if key in _DEFAULTS[section]:
+                valid[key] = val
+            else:
+                _warn(f"unknown key {section}.{key} in {path}; ignored")
+        cfg[section].update(valid)
     return cfg

--- a/mcpclient_speech/config.py
+++ b/mcpclient_speech/config.py
@@ -7,7 +7,7 @@ _DEFAULTS: dict = {
         "base_url": "http://localhost:11434/v1/",
         "api_key": "ollama",
     },
-    "behavior": {
+    "face": {
         "omit_names_and_prefs": False,
     },
     "devices": {},

--- a/mcpclient_speech/config.toml
+++ b/mcpclient_speech/config.toml
@@ -1,0 +1,11 @@
+[llm]
+model    = "PetrosStav/gemma3-tools:12b"
+base_url = "http://localhost:11434/v1/"
+api_key  = "ollama"
+
+[face]
+omit_names_and_prefs = false
+
+[devices]
+# camera     = 0   # uncomment to set default camera index (face client only)
+# microphone = 0   # uncomment to set default microphone device index

--- a/mcpclient_speech/eyewindow.py
+++ b/mcpclient_speech/eyewindow.py
@@ -64,6 +64,7 @@ class EyeWindow:
         self.txt0 = CCText(self.win.fig, (0.5, 0.9), name, 1.0/20)
         self.txt1 = CCText(self.win.fig, (0.5, 0.45), "", 1.0/20)
         self.txt2 = CCText(self.win.fig, (0.5, 0.38), "", 1.0/40)
+        self.txt_indicator = CCText(self.win.fig, (0.05, 0.95), "", 1.0/40)
         self.cam_ax = self.win.fig.add_axes((0.78, 0.80, 0.20, 0.18))
         self.cam_ax.set_xticks([]); self.cam_ax.set_yticks([])
         for s in self.cam_ax.spines.values():
@@ -94,6 +95,7 @@ class EyeWindow:
         self.txt0.resize()
         self.txt1.resize()
         self.txt2.resize()
+        self.txt_indicator.resize()
 
     def exit_event(self, ev):
         if self.exitfunc:
@@ -105,6 +107,9 @@ class EyeWindow:
             self.eye.set_color(col)
             self.txt1.text.set_text(txt1)
             self.txt2.text.set_text(txt2)
+
+    def set_indicator(self, text):
+        self.txt_indicator.text.set_text(text or "")
 
     def key_press_event(self, event):
         if event.key == "control":

--- a/mcpclient_speech/interaction_logger.py
+++ b/mcpclient_speech/interaction_logger.py
@@ -1,0 +1,103 @@
+"""JSONL interaction logger for the face-tracking speech client.
+
+Each session writes a stream of `{"ts": ..., "type": ..., ...}` events to a
+single JSONL file. Two output modes are supported via `from_args`:
+
+  * `--log-file PATH` — overwrite a single file every run.
+  * `--log-dir DIR`   — create a new `<UTC-timestamp>Z.jsonl` per run inside DIR.
+
+Failures inside `log()` are caught and re-emitted as warnings on the standard
+"mcpclient_speech" logger so a broken disk never crashes the application.
+"""
+
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+logger = logging.getLogger("mcpclient_speech")
+
+SCHEMA_VERSION = 1
+
+
+def _json_default(obj):
+    # OpenAI ChatCompletionMessage and related pydantic models
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump(mode="json", exclude_none=True)
+        except TypeError:
+            return model_dump(exclude_none=True)
+    to_dict = getattr(obj, "to_dict", None)
+    if callable(to_dict):
+        try:
+            return to_dict()
+        except Exception:
+            pass
+    return str(obj)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _utc_now_filename() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S_%f") + "Z"
+
+
+class InteractionLogger:
+    def __init__(self, path: str, *, overwrite: bool):
+        self.path = path
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        self._fp = open(path, "w" if overwrite else "a", encoding="utf-8")
+        self._start_monotonic = time.monotonic()
+        self._closed = False
+
+    @classmethod
+    def from_args(cls, args) -> "InteractionLogger | None":
+        log_file = getattr(args, "log_file", None)
+        log_dir = getattr(args, "log_dir", None)
+        if log_file:
+            return cls(log_file, overwrite=True)
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+            path = os.path.join(log_dir, _utc_now_filename() + ".jsonl")
+            return cls(path, overwrite=False)
+        return None
+
+    def log(self, event_type: str, **fields) -> None:
+        if self._closed:
+            return
+        try:
+            payload = {"ts": _utc_now_iso(), "type": event_type, **fields}
+            line = json.dumps(payload, default=_json_default, ensure_ascii=False)
+            self._fp.write(line + "\n")
+            self._fp.flush()
+        except Exception:
+            logger.warning("interaction logger: failed to write %s event", event_type, exc_info=True)
+
+    def close(self, reason: str = "normal", **extra) -> None:
+        if self._closed:
+            return
+        try:
+            duration = round(time.monotonic() - self._start_monotonic, 3)
+            payload = {
+                "ts": _utc_now_iso(),
+                "type": "session_end",
+                "reason": reason,
+                "duration_seconds": duration,
+                **extra,
+            }
+            self._fp.write(json.dumps(payload, default=_json_default, ensure_ascii=False) + "\n")
+            self._fp.flush()
+        except Exception:
+            logger.warning("interaction logger: failed to write session_end", exc_info=True)
+        finally:
+            try:
+                self._fp.close()
+            except Exception:
+                pass
+            self._closed = True

--- a/mcpclient_speech/interaction_logger.py
+++ b/mcpclient_speech/interaction_logger.py
@@ -61,6 +61,8 @@ class InteractionLogger:
         log_file = getattr(args, "log_file", None)
         log_dir = getattr(args, "log_dir", None)
         if log_file:
+            if not log_file.endswith(".jsonl"):
+                log_file = log_file + ".jsonl"
             return cls(log_file, overwrite=True)
         if log_dir:
             os.makedirs(log_dir, exist_ok=True)

--- a/mcpclient_speech/mcpclient_speech.py
+++ b/mcpclient_speech/mcpclient_speech.py
@@ -17,12 +17,7 @@ from openai import OpenAI
 from readnb import *
 from eyewindow import *
 from record import *
-
-ollama_config = {
-    "model": "PetrosStav/gemma3-tools:12b",
-    "base_url": "http://localhost:11434/v1/",
-    "api_key": "ollama"
-}
+from config import load_config
 
 messages_trunclen = 4
 messages = []
@@ -180,6 +175,10 @@ async def main():
     global has_init
     global has_exit
 
+    cfg = load_config()
+    ollama_config = cfg["llm"]
+    mic_index = cfg["devices"].get("microphone")
+
     # Connect via stdio to a local script
     async with Client(transport=SSETransport("http://127.0.0.1:8000/sse")) as client:
         ### Initialization phase
@@ -220,8 +219,7 @@ async def main():
 
         make_nonblocking(sys.stdin)
 
-        #if init_audio(microphone_name="sof-hda-dsp", sample_rate=16000):
-        if init_audio():
+        if init_audio(device_idx=mic_index):
             print('Initialized speech recognition and synthesis')
         else:
             print('Error: failed to initialize audio')

--- a/mcpclient_speech/mcpclient_speech.py
+++ b/mcpclient_speech/mcpclient_speech.py
@@ -51,6 +51,11 @@ def on_release(_event, state):
         state['evtime'] = time.time()
         state['newstate'] = 'processing'
 
+def kp_stop_listening(_event, state):
+    if state['currstate'] in ('listening1', 'listening2'):
+        state['evtime'] = time.time()
+        state['newstate'] = 'processing'
+
 def check_statechange(state):
     win.check_events()
     t = time.time()
@@ -244,6 +249,7 @@ async def main():
         win.set_exit_callback(on_exit, state)
         win.keydict["c"] = (kp_clear_messages, None)
         win.keydict["r"] = (kp_repeat_last, state)
+        win.keydict[" "] = (kp_stop_listening, state)
         win.check_events()
         print('Created the interaction window')
 

--- a/mcpclient_speech/mcpclient_speech.py
+++ b/mcpclient_speech/mcpclient_speech.py
@@ -391,5 +391,4 @@ async def main(args):
         print('Exiting')
 
 if __name__ == "__main__":
-    import asyncio
     asyncio.run(main(parse_args()))

--- a/mcpclient_speech/mcpclient_speech.py
+++ b/mcpclient_speech/mcpclient_speech.py
@@ -3,6 +3,7 @@
 # and using a speechbased LLM interface with whisper and piper.
 #
 
+import argparse
 import asyncio
 from fastmcp import Client, exceptions
 from fastmcp.client.transports import SSETransport
@@ -168,7 +169,13 @@ def kp_repeat_last(_event, state):
     state['evtime'] = time.time()
     state['newstate'] = 'repeat'
 
-async def main():
+def parse_args():
+    parser = argparse.ArgumentParser(description="MCP Speech Client (push-to-talk)")
+    parser.add_argument('--config', default=None, help='Path to config TOML file (default: config.toml next to this script)')
+    return parser.parse_args()
+
+
+async def main(args):
     global messages
     global tools
     global win
@@ -180,7 +187,7 @@ async def main():
     global has_init
     global has_exit
 
-    cfg = load_config()
+    cfg = load_config(args.config)
     ollama_config = cfg["llm"]
     mic_index = cfg["devices"].get("microphone")
 
@@ -385,4 +392,4 @@ async def main():
 
 if __name__ == "__main__":
     import asyncio
-    asyncio.run(main())
+    asyncio.run(main(parse_args()))

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -599,7 +599,7 @@ async def main(args):
             # focus-in -> if listen first do focus out, fetch profile, go to greet
             # sound-ready -> go to process (stop listen?)
             while not newstate:
-                time.sleep(0.05)
+                await asyncio.sleep(0.05)
                 newstate = check_statechange(state)
                 ### Remove?
                 if nb_available(sys.stdin):
@@ -722,9 +722,9 @@ async def main(args):
                     voice_out.speak_async(reply_text, lang)
                     while voice_out.speaking:
                         win.check_events()
-                        time.sleep(0.05)
+                        await asyncio.sleep(0.05)
                     if not voice_out.interrupted:
-                        time.sleep(0.5)  # let room reverb decay before mic reopens
+                        await asyncio.sleep(0.5)  # let room reverb decay before mic reopens
                 if state['newstate'] is None or state['newstate']=='listen':
                     set_state(state, 'listen')
                 else:

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -31,14 +31,9 @@ from face_tracker import (
     FaceTracker, FaceDatabase, EmotionDetector, FaceEventType,
 )
 import cv2
+from config import load_config
 
 logger = logging.getLogger("mcpclient_speech")
-
-ollama_config = {
-    "model": "PetrosStav/gemma3-tools:12b",
-    "base_url": "http://localhost:11434/v1/",
-    "api_key": "ollama"
-}
 
 default_lang = "sv"
 messages_trunclen = 8
@@ -109,8 +104,8 @@ def parse_args():
     parser.add_argument('-l', '--list-cameras', action='store_true', help='List available cameras and exit')
     parser.add_argument('--camera', type=int, default=None, help='Camera index (default: auto-detect)')
     parser.add_argument('--server', default="http://127.0.0.1:8000/sse", help='MCP server SSE URL')
-    parser.add_argument('--llm-model', default="PetrosStav/gemma3-tools:12b", help='LLM model name')
-    parser.add_argument('--llm-url', default="http://localhost:11434/v1/", help='LLM base URL')
+    parser.add_argument('--llm-model', default=None, help='LLM model name')
+    parser.add_argument('--llm-url', default=None, help='LLM base URL')
     parser.add_argument('-m', '--list-mics', action='store_true', help='List available microphones and exit')
     parser.add_argument('--mic', type=int, default=None, help='Microphone device index (default: system default)')
     parser.add_argument('-v', '--verbose', action='count', default=0, help='Increase verbosity (-v for INFO, -vv for DEBUG)')
@@ -730,6 +725,8 @@ async def main(args):
         print('Exiting')
 
 def run():
+    global omit_names_and_prefs
+
     args = parse_args()
 
     # Configure logging
@@ -765,7 +762,21 @@ def run():
             print("No cameras found")
         sys.exit(0)
 
-    # Resolve camera index
+    # Load config file; CLI args take priority over config, config over built-in defaults
+    cfg = load_config()
+
+    if args.llm_model is None:
+        args.llm_model = cfg["llm"]["model"]
+    if args.llm_url is None:
+        args.llm_url = cfg["llm"]["base_url"]
+    if args.camera is None:
+        args.camera = cfg["devices"].get("camera")
+    if args.mic is None:
+        args.mic = cfg["devices"].get("microphone")
+
+    omit_names_and_prefs = cfg["behavior"]["omit_names_and_prefs"]
+
+    # Resolve camera index (auto-detect if still None after config)
     if args.camera is None:
         args.camera = find_first_camera()
         if args.camera is not None:

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -172,7 +172,7 @@ def kp_toggle_mute(_event, _obj):
 
 def kp_force_process(_event, _obj):
     if state.get('currstate') == 'listen' and voice_in is not None:
-        voice_in._cancel_listen = True
+        voice_in.flush_listen()
 
 def on_exit(state):
     logger.info("Exit event")

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -109,6 +109,7 @@ def parse_args():
     parser.add_argument('-m', '--list-mics', action='store_true', help='List available microphones and exit')
     parser.add_argument('--mic', type=int, default=None, help='Microphone device index (default: system default)')
     parser.add_argument('-v', '--verbose', action='count', default=0, help='Increase verbosity (-v for INFO, -vv for DEBUG)')
+    parser.add_argument('--config', default=None, help='Path to config TOML file (default: config.toml next to this script)')
     return parser.parse_args()
 
 
@@ -776,7 +777,7 @@ def run():
         sys.exit(0)
 
     # Load config file; CLI args take priority over config, config over built-in defaults
-    cfg = load_config()
+    cfg = load_config(args.config)
 
     if args.llm_model is None:
         args.llm_model = cfg["llm"]["model"]

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -5,11 +5,13 @@
 
 import argparse
 import asyncio
+import atexit
 from fastmcp import Client, exceptions
 from fastmcp.client.transports import SSETransport
 import json
 import logging
 import os
+import subprocess
 import threading
 import time
 import sys
@@ -32,8 +34,29 @@ from face_tracker import (
 )
 import cv2
 from config import load_config
+from interaction_logger import InteractionLogger
 
 logger = logging.getLogger("mcpclient_speech")
+
+interaction_log: InteractionLogger | None = None
+
+
+def _ilog(event_type: str, **fields) -> None:
+    if interaction_log is not None:
+        interaction_log.log(event_type, **fields)
+
+
+def _git_commit_short() -> str | None:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+        return out.decode().strip() or None
+    except Exception:
+        return None
 
 default_lang = "sv"
 messages_trunclen = 8
@@ -110,6 +133,9 @@ def parse_args():
     parser.add_argument('--mic', type=int, default=None, help='Microphone device index (default: system default)')
     parser.add_argument('-v', '--verbose', action='count', default=0, help='Increase verbosity (-v for INFO, -vv for DEBUG)')
     parser.add_argument('--config', default=None, help='Path to config TOML file (default: config.toml next to this script)')
+    log_group = parser.add_mutually_exclusive_group()
+    log_group.add_argument('--log-file', default=None, help='Log every interaction event to this JSONL file (overwrites on each run)')
+    log_group.add_argument('--log-dir', default=None, help='Log every interaction event to a new timestamped JSONL file in this directory')
     return parser.parse_args()
 
 
@@ -155,12 +181,14 @@ def extract_language(info):
 def kp_toggle_mute(_event, _obj):
     global muted
     muted = not muted
+    interrupted = False
     if muted:
         if listener:
             listener.paused = True
         if voice_in is not None:
             voice_in._cancel_listen = True
         if voice_out is not None:
+            interrupted = bool(getattr(voice_out, "speaking", False))
             voice_out.stop_speaking()
         logger.info("Muted")
         if win:
@@ -169,6 +197,7 @@ def kp_toggle_mute(_event, _obj):
         logger.info("Unmuted")
         if win:
             win.set_state(state.get('currstate', 'wait'))
+    _ilog("mute", muted=muted, interrupted_speech=interrupted)
 
 def kp_force_process(_event, _obj):
     if state.get('currstate') == 'listen' and voice_in is not None:
@@ -191,6 +220,7 @@ def kp_save_recording(_event, _obj):
 
 def on_exit(state):
     logger.info("Exit event")
+    _ilog("state_change", **{"from": state.get('currstate'), "to": "exit"})
     state['evtime'] = time.time()
     state['newstate'] = 'exit'
 
@@ -199,6 +229,7 @@ def on_face_change(id):
     logger.info("Face change event")
     if muted or state['newstate'] == 'exit':
         return
+    prev_face_id = next((pid for pid, p in persondict.items() if p is curr_person), None)
     if curr_person:
         logger.info("Storing current person")
         curr_person.lasttime = time.time()
@@ -214,9 +245,16 @@ def on_face_change(id):
             pref = extract_value("Preferences:", info)
             if pref:
                 curr_person.profileinfo = pref
+            _ilog("person_distillation",
+                  face_id=prev_face_id,
+                  raw_summary=info,
+                  parsed_name=name,
+                  parsed_lang=lang,
+                  parsed_preferences=pref)
         else:
             print("(Nothing new to extract)")
     if id is None:
+        _ilog("face_change", face_id=None, status="none", name=None, lang=None, last_seen_seconds_ago=None)
         messages = []
         curr_person = None
         state['evtime'] = time.time()
@@ -226,11 +264,25 @@ def on_face_change(id):
             curr_person = persondict[id]
             messages = list(curr_person.lastmessages or [])
             logger.info("Retrieving person %s from memory", id)
+            last_seen = (time.time() - curr_person.lasttime) if curr_person.lasttime else None
+            _ilog("face_change",
+                  face_id=id,
+                  status="known",
+                  name=curr_person.name,
+                  lang=curr_person.lang,
+                  last_seen_seconds_ago=last_seen)
+            _ilog("person_resumed",
+                  face_id=id,
+                  name=curr_person.name,
+                  lang=curr_person.lang,
+                  profileinfo=curr_person.profileinfo,
+                  restored_message_count=len(messages))
         else:
             curr_person = Person(None)
             persondict[id] = curr_person
             messages = []
             logger.info("Creating person %s", id)
+            _ilog("face_change", face_id=id, status="new", name=None, lang=None, last_seen_seconds_ago=None)
         state['evtime'] = time.time()
         if curr_person.lasttime and state['evtime'] - curr_person.lasttime < 60:
             state['newstate'] = 'listen'
@@ -259,6 +311,7 @@ def check_statechange(state):
         return False
 
 def set_state(state, newstate):
+    prev = state.get('currstate')
     if listener:
         listener.paused = muted or (newstate != 'listen')
     state['currstate'] = newstate
@@ -266,6 +319,8 @@ def set_state(state, newstate):
     state['newstate'] = None
     win.set_state('muted' if muted else newstate)
     win.check_events()
+    if prev != newstate:
+        _ilog("state_change", **{"from": prev, "to": newstate})
 
 def set_win_state(newstate):
     win.set_state('muted' if muted else newstate)
@@ -312,6 +367,7 @@ async def system_message(client, lang):
         else:
             pr = await client.get_prompt("get_service_prompt", {})
         txt = pr.messages[0].content.text
+        _ilog("mcp_prompt", kind="system", lang=lang, content=txt)
     else:
         txt = "You are a helpful assistant that can control various devices."
     return {"role": "system", "content": txt}
@@ -323,6 +379,7 @@ async def augmentation_message(client, lang):
         else:
             pr = await client.get_prompt("get_service_augmentation", {})
         txt = pr.messages[0].content.text
+        _ilog("mcp_prompt", kind="augmentation", lang=lang, content=txt)
         return {"role": "system", "content": txt}
     else:
         return False
@@ -378,6 +435,7 @@ def compose_messages(sysp, mlst, augs):
 def clear_messages():
     global messages
     messages = []
+    _ilog("clear_history")
 
 ### remove next 2?
 def trim_last_message():
@@ -396,6 +454,24 @@ def messagedump(messages):
     print("\nMessages:")
     for msg in messages:
         print(msg)
+
+def _serialize_tool_calls(tool_calls):
+    if not tool_calls:
+        return []
+    out = []
+    for tc in tool_calls:
+        args_str = tc.function.arguments
+        try:
+            args_parsed = json.loads(args_str)
+        except (TypeError, ValueError):
+            args_parsed = None
+        out.append({
+            "id": tc.id,
+            "name": tc.function.name,
+            "arguments": args_str,
+            "arguments_parsed": args_parsed,
+        })
+    return out
 
 async def main(args):
     global messages
@@ -484,11 +560,25 @@ async def main(args):
         ### Initialize voice_input library, as ContinuousListener with on_speech as callback here
         voice_in = VoiceInput(device=args.mic)
         voice_in.subscribe(
+            lambda ev: _ilog("transcription",
+                             text=ev.payload.text,
+                             language=ev.payload.language,
+                             language_probability=ev.payload.language_probability,
+                             audio_duration_ms=ev.payload.audio_duration_ms),
+            event_types={VoiceEventType.TRANSCRIPTION_COMPLETE},
+        )
+        voice_in.subscribe(
             lambda ev: on_speech(ev.payload.text),
             event_types={VoiceEventType.TRANSCRIPTION_COMPLETE},
         )
         voice_in.subscribe(
             lambda ev: _refresh_save_indicator(ev.payload.remaining),
+            event_types={VoiceEventType.RECORDING_SAVED},
+        )
+        voice_in.subscribe(
+            lambda ev: _ilog("recording_saved",
+                             remaining=ev.payload.remaining,
+                             wav_path=ev.payload.path),
             event_types={VoiceEventType.RECORDING_SAVED},
         )
         print('Loading whisper model...')
@@ -610,6 +700,7 @@ async def main(args):
 
         set_state(state, 'wait')
         newstate = False
+        prompt_source = None
         while True:
 
             # In this loop, state is either wait or listen
@@ -628,11 +719,15 @@ async def main(args):
                         res = res.strip(" \n")
                         if res[0:5] == "/lang":
                             txtlang = res[5:].strip(" ")
+                            _ilog("stdin_command", cmd="/lang", arg=txtlang)
                         elif res[0:5] == "/exit":
+                            _ilog("stdin_command", cmd="/exit", arg=None)
                             newstate = 'exit'
                         elif len(res):
+                            _ilog("stdin_command", cmd="text", arg=res)
                             prompt = res
                             lang = txtlang
+                            prompt_source = "stdin"
                             newstate = 'process'
                             set_state(state, newstate)
     
@@ -654,6 +749,7 @@ async def main(args):
                         if voice_in and voice_in.detected_language:
                             lang = voice_in.detected_language
                         curr_prompt = ""
+                        prompt_source = "speech"
 
                 if newstate == 'greet':
                     if curr_person and curr_person.lang and curr_person.lang in ['en','sv','de','fr','es']:
@@ -672,6 +768,8 @@ async def main(args):
                 augpromptlist.append(langprompt)
                 if newstate == 'process':
                     print("\n  User: (", lang, ") ", prompt)
+                    _ilog("user_turn", kind=prompt_source or "unknown", content=prompt, lang=lang)
+                    prompt_source = None
                     messages.append(user_message(prompt))
                 elif newstate == 'greet':
                     if omit_names_and_prefs:
@@ -679,20 +777,46 @@ async def main(args):
                     else:
                         greetprompt = greet_prompt()
                     print("\n  Greeting:", greetprompt['content'])
+                    _ilog("user_turn",
+                          kind="greet_noname" if omit_names_and_prefs else "greet",
+                          content=greetprompt['content'],
+                          lang=lang)
                     messages.append(greetprompt)
 
+                iteration = 0
                 msg = compose_messages(sysprompt, messages, augpromptlist)
                 #messagedump(msg)
-                response = openai.chat.completions.create(
-                    model=model,
-                    messages=msg,
-                    tools=tools,
-                )
-    
+                _ilog("llm_request",
+                      iteration=iteration,
+                      model=model,
+                      messages_full=list(messages),
+                      messages_sent=msg,
+                      tool_count=len(tools or []))
+                try:
+                    response = openai.chat.completions.create(
+                        model=model,
+                        messages=msg,
+                        tools=tools,
+                    )
+                except Exception as e:
+                    _ilog("llm_error",
+                          iteration=iteration,
+                          error_class=type(e).__name__,
+                          error_message=str(e))
+                    raise
+                _ilog("llm_response",
+                      iteration=iteration,
+                      content=response.choices[0].message.content,
+                      tool_calls=_serialize_tool_calls(response.choices[0].message.tool_calls))
+
                 tool_calls = response.choices[0].message.tool_calls
                 while tool_calls:
                     messages.append(response.choices[0].message)
                     for tool_call in tool_calls:
+                        try:
+                            args_parsed = json.loads(tool_call.function.arguments)
+                        except (TypeError, ValueError):
+                            args_parsed = None
                         try:
                             result = await client.call_tool(tool_call.function.name,
                                                             json.loads(tool_call.function.arguments))
@@ -709,8 +833,14 @@ async def main(args):
                             }
                             print("\n  Function: ", tool_call.function.name, "(", tool_call.function.arguments, ")")
                             print(  "  Result:   ", resulttxt)
+                            _ilog("mcp_tool_call",
+                                  name=tool_call.function.name,
+                                  arguments=tool_call.function.arguments,
+                                  arguments_parsed=args_parsed,
+                                  success=True,
+                                  result_text=resulttxt)
                             messages.append(result_message)
-                        except exceptions.ToolError:
+                        except exceptions.ToolError as te:
                             result_message = {
                                 "role": "tool",
                                 "content": json.dumps({
@@ -719,15 +849,39 @@ async def main(args):
                                 "tool_call_id": tool_call.id
                             }
                             print("\n  Unknown function: ", tool_call.function.name, "(", tool_call.function.arguments, ")")
+                            _ilog("mcp_tool_call",
+                                  name=tool_call.function.name,
+                                  arguments=tool_call.function.arguments,
+                                  arguments_parsed=args_parsed,
+                                  success=False,
+                                  error_message=f"ToolError: {te}")
                             messages.append(result_message)
-    
+
+                    iteration += 1
                     msg = compose_messages(sysprompt, messages, augpromptlist)
                     #messagedump(msg)
-                    response = openai.chat.completions.create(
-                        model=model,
-                        messages=msg,
-                        tools=tools,
-                    )
+                    _ilog("llm_request",
+                          iteration=iteration,
+                          model=model,
+                          messages_full=list(messages),
+                          messages_sent=msg,
+                          tool_count=len(tools or []))
+                    try:
+                        response = openai.chat.completions.create(
+                            model=model,
+                            messages=msg,
+                            tools=tools,
+                        )
+                    except Exception as e:
+                        _ilog("llm_error",
+                              iteration=iteration,
+                              error_class=type(e).__name__,
+                              error_message=str(e))
+                        raise
+                    _ilog("llm_response",
+                          iteration=iteration,
+                          content=response.choices[0].message.content,
+                          tool_calls=_serialize_tool_calls(response.choices[0].message.tool_calls))
                     tool_calls = response.choices[0].message.tool_calls
 
                 # No tool calls, just print the response.
@@ -735,7 +889,11 @@ async def main(args):
                 reply_text = response.choices[0].message.content or ""
                 print(f'\n  Response: {reply_text}  (lang={lang})')
                 set_win_state('talk')
-                if reply_text and not muted:
+                if not reply_text:
+                    _ilog("tts_speak", text="", lang=lang, status="empty")
+                elif muted:
+                    _ilog("tts_speak", text=reply_text, lang=lang, status="muted_suppressed")
+                else:
                     # Simple TTS: pause mic for the whole utterance, no AEC.
                     # Resume is handled by the state-machine transition below.
                     listener.paused = True
@@ -751,6 +909,10 @@ async def main(args):
                             await asyncio.sleep(0.05)
                         if not voice_out.interrupted:
                             await asyncio.sleep(0.5)  # let room reverb decay before mic reopens
+                    _ilog("tts_speak",
+                          text=reply_text,
+                          lang=lang,
+                          status="interrupted" if getattr(voice_out, "interrupted", False) else "spoken")
                 if state['newstate'] is None or state['newstate']=='listen':
                     set_state(state, 'listen')
                 else:
@@ -825,16 +987,51 @@ def run():
             print("ERROR: No cameras found. Use --camera N.")
             sys.exit(1)
 
+    global interaction_log
+    interaction_log = InteractionLogger.from_args(args)
+    if interaction_log is not None:
+        atexit.register(interaction_log.close, "atexit")
+        _ilog("session_start",
+              schema=1,
+              pid=os.getpid(),
+              git_commit=_git_commit_short(),
+              args={
+                  "server": args.server,
+                  "llm_model": args.llm_model,
+                  "llm_url": args.llm_url,
+                  "lang_default": default_lang,
+                  "mic": args.mic,
+                  "camera": args.camera,
+                  "omit_names_and_prefs": omit_names_and_prefs,
+                  "log_file": args.log_file,
+                  "log_dir": args.log_dir,
+              })
+
     try:
         asyncio.run(main(args))
     except (ConnectionError, OSError) as e:
         print(f"ERROR: Cannot connect to MCP server at {args.server}: {e}")
+        if interaction_log is not None:
+            interaction_log.close("connection_error",
+                                  error_class=type(e).__name__,
+                                  error_message=str(e))
         sys.exit(1)
     except KeyboardInterrupt:
         print("\nShutting down")
+        if interaction_log is not None:
+            interaction_log.close("keyboard_interrupt")
     except Exception as e:
+        import traceback
         logger.error("Unexpected error: %s", e)
+        if interaction_log is not None:
+            interaction_log.close("exception",
+                                  error_class=type(e).__name__,
+                                  error_message=str(e),
+                                  traceback=traceback.format_exc())
         sys.exit(1)
+    else:
+        if interaction_log is not None:
+            interaction_log.close("normal")
 
 
 if __name__ == "__main__":

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -165,6 +165,10 @@ def kp_toggle_mute(_event, _obj):
         if win:
             win.set_state(state.get('currstate', 'wait'))
 
+def kp_force_process(_event, _obj):
+    if state.get('currstate') == 'listen' and voice_in is not None:
+        voice_in._cancel_listen = True
+
 def on_exit(state):
     logger.info("Exit event")
     state['evtime'] = time.time()
@@ -452,6 +456,7 @@ async def main(args):
         win = EyeWindow(name, sdict, 'ready')
         win.set_exit_callback(on_exit, state)
         win.keydict["m"] = (kp_toggle_mute, None)
+        win.keydict[" "] = (kp_force_process, None)
         win.check_events()
         print('Created the interaction window')
 

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -788,7 +788,7 @@ def run():
     if args.mic is None:
         args.mic = cfg["devices"].get("microphone")
 
-    omit_names_and_prefs = cfg["behavior"]["omit_names_and_prefs"]
+    omit_names_and_prefs = cfg["face"]["omit_names_and_prefs"]
 
     # Resolve camera index (auto-detect if still None after config)
     if args.camera is None:

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -176,6 +176,19 @@ def kp_force_process(_event, _obj):
     else:
         logger.debug("force-process pressed but ignored (state=%s)", state.get('currstate'))
 
+def _refresh_save_indicator(count: int) -> None:
+    if win is None:
+        return
+    win.set_indicator(f"Save next {count}" if count > 0 else None)
+    win.check_events()
+
+def kp_save_recording(_event, _obj):
+    if voice_in is None:
+        return
+    pending = voice_in.save_next_recordings(1)
+    _refresh_save_indicator(pending)
+    logger.info("Save-next-recordings count is now %d", pending)
+
 def on_exit(state):
     logger.info("Exit event")
     state['evtime'] = time.time()
@@ -464,6 +477,7 @@ async def main(args):
         win.set_exit_callback(on_exit, state)
         win.keydict["m"] = (kp_toggle_mute, None)
         win.keydict[" "] = (kp_force_process, None)
+        win.keydict["s"] = (kp_save_recording, None)
         win.check_events()
         print('Created the interaction window')
 
@@ -472,6 +486,10 @@ async def main(args):
         voice_in.subscribe(
             lambda ev: on_speech(ev.payload.text),
             event_types={VoiceEventType.TRANSCRIPTION_COMPLETE},
+        )
+        voice_in.subscribe(
+            lambda ev: _refresh_save_indicator(ev.payload.remaining),
+            event_types={VoiceEventType.RECORDING_SAVED},
         )
         print('Loading whisper model...')
         voice_in.load_sync()

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -990,6 +990,7 @@ def run():
     global interaction_log
     interaction_log = InteractionLogger.from_args(args)
     if interaction_log is not None:
+        print(f"Interaction log: {interaction_log.path}")
         atexit.register(interaction_log.close, "atexit")
         _ilog("session_start",
               schema=1,
@@ -1003,7 +1004,7 @@ def run():
                   "mic": args.mic,
                   "camera": args.camera,
                   "omit_names_and_prefs": omit_names_and_prefs,
-                  "log_file": args.log_file,
+                  "log_path": interaction_log.path,
                   "log_dir": args.log_dir,
               })
 

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -160,7 +160,7 @@ def kp_toggle_mute(_event, _obj):
             listener.paused = True
         if voice_in is not None:
             voice_in._cancel_listen = True
-        if voice_out is not None and voice_out.speaking:
+        if voice_out is not None:
             voice_out.stop_speaking()
         logger.info("Muted")
         if win:
@@ -173,6 +173,8 @@ def kp_toggle_mute(_event, _obj):
 def kp_force_process(_event, _obj):
     if state.get('currstate') == 'listen' and voice_in is not None:
         voice_in.flush_listen()
+    else:
+        logger.debug("force-process pressed but ignored (state=%s)", state.get('currstate'))
 
 def on_exit(state):
     logger.info("Exit event")
@@ -720,11 +722,17 @@ async def main(args):
                     # Resume is handled by the state-machine transition below.
                     listener.paused = True
                     voice_out.speak_async(reply_text, lang)
-                    while voice_out.speaking:
-                        win.check_events()
-                        await asyncio.sleep(0.05)
-                    if not voice_out.interrupted:
-                        await asyncio.sleep(0.5)  # let room reverb decay before mic reopens
+                    # Give the async thread a moment to flip speaking=True so we
+                    # don't fall through (and skip the reverb wait) on a slow start.
+                    deadline = time.monotonic() + 0.2
+                    while not voice_out.speaking and time.monotonic() < deadline:
+                        await asyncio.sleep(0.01)
+                    if voice_out.speaking:
+                        while voice_out.speaking:
+                            win.check_events()
+                            await asyncio.sleep(0.05)
+                        if not voice_out.interrupted:
+                            await asyncio.sleep(0.5)  # let room reverb decay before mic reopens
                 if state['newstate'] is None or state['newstate']=='listen':
                     set_state(state, 'listen')
                 else:

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -249,11 +249,11 @@ def set_state(state, newstate):
     state['currstate'] = newstate
     state['statetime'] = time.time()
     state['newstate'] = None
-    win.set_state(newstate)
+    win.set_state('muted' if muted else newstate)
     win.check_events()
 
 def set_win_state(newstate):
-    win.set_state(newstate)
+    win.set_state('muted' if muted else newstate)
     win.check_events()
 
 def init_llm(conf):

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -157,6 +157,8 @@ def kp_toggle_mute(_event, _obj):
     if muted:
         if listener:
             listener.paused = True
+        if voice_in is not None:
+            voice_in._cancel_listen = True
         logger.info("Muted")
         if win:
             win.set_state('muted')

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -159,6 +159,8 @@ def kp_toggle_mute(_event, _obj):
             listener.paused = True
         if voice_in is not None:
             voice_in._cancel_listen = True
+        if voice_out is not None and voice_out.speaking:
+            voice_out.stop_speaking()
         logger.info("Muted")
         if win:
             win.set_state('muted')
@@ -712,12 +714,16 @@ async def main(args):
                 reply_text = response.choices[0].message.content or ""
                 print(f'\n  Response: {reply_text}  (lang={lang})')
                 set_win_state('talk')
-                if reply_text:
+                if reply_text and not muted:
                     # Simple TTS: pause mic for the whole utterance, no AEC.
                     # Resume is handled by the state-machine transition below.
                     listener.paused = True
-                    voice_out.speak(reply_text, lang)
-                    time.sleep(0.5)  # let room reverb decay before mic reopens
+                    voice_out.speak_async(reply_text, lang)
+                    while voice_out.speaking:
+                        win.check_events()
+                        time.sleep(0.05)
+                    if not voice_out.interrupted:
+                        time.sleep(0.5)  # let room reverb decay before mic reopens
                 if state['newstate'] is None or state['newstate']=='listen':
                     set_state(state, 'listen')
                 else:

--- a/mcpclient_speech/record.py
+++ b/mcpclient_speech/record.py
@@ -16,18 +16,29 @@ def init_audio(microphone_name=None, sample_rate=0, device_idx=None) -> bool:
     device_sample_rate = DEFAULT_SAMPLE_RATE if sample_rate == 0 else sample_rate
     audio = pyaudio.PyAudio()
     if device_idx is not None:
+        try:
+            info = audio.get_device_info_by_index(device_idx)
+        except (IOError, OSError) as e:
+            print(f"Error: invalid microphone index {device_idx}: {e}")
+            return False
         device_index = device_idx
-        name = audio.get_device_info_by_index(device_idx).get("name", str(device_idx))
-        print(f"Using microphone {name} at {device_idx}")
+        print(f"Using microphone {info.get('name', str(device_idx))} at {device_idx}")
         return True
-    if microphone_name is None:
-        microphone_name = 'Samson C03U'
-    device_index, device_name = hardware_devices.find_microphone_index(microphone_name, audio=audio, sample_rate=device_sample_rate)
-    if device_index >= 0:
-        print(f"Found microphone {device_name} at {device_index}")
-        return True
-    print(f"Error: could not find microphone matching {microphone_name} supporting sample rate {device_sample_rate}")
-    return False
+    if microphone_name is not None:
+        device_index, device_name = hardware_devices.find_microphone_index(microphone_name, audio=audio, sample_rate=device_sample_rate)
+        if device_index >= 0:
+            print(f"Found microphone {device_name} at {device_index}")
+            return True
+        print(f"Error: could not find microphone matching {microphone_name} supporting sample rate {device_sample_rate}")
+        return False
+    try:
+        info = audio.get_default_input_device_info()
+    except IOError as e:
+        print(f"Error: no default input device available: {e}")
+        return False
+    device_index = info["index"]
+    print(f"Using default microphone {info.get('name', '')} at {device_index}")
+    return True
 
 def exit_audio():
     global audio

--- a/mcpclient_speech/record.py
+++ b/mcpclient_speech/record.py
@@ -11,12 +11,17 @@ device_sample_rate = DEFAULT_SAMPLE_RATE
 whisperdir = "../../whisper.cpp/"
 tempfile = "temp.wav"
 
-def init_audio(microphone_name=None, sample_rate=0) -> bool:
+def init_audio(microphone_name=None, sample_rate=0, device_idx=None) -> bool:
     global audio, device_index, device_sample_rate
-    if microphone_name is None:
-        microphone_name = 'Samson C03U'
     device_sample_rate = DEFAULT_SAMPLE_RATE if sample_rate == 0 else sample_rate
     audio = pyaudio.PyAudio()
+    if device_idx is not None:
+        device_index = device_idx
+        name = audio.get_device_info_by_index(device_idx).get("name", str(device_idx))
+        print(f"Using microphone {name} at {device_idx}")
+        return True
+    if microphone_name is None:
+        microphone_name = 'Samson C03U'
     device_index, device_name = hardware_devices.find_microphone_index(microphone_name, audio=audio, sample_rate=device_sample_rate)
     if device_index >= 0:
         print(f"Found microphone {device_name} at {device_index}")

--- a/mcpclient_speech/replay_log.py
+++ b/mcpclient_speech/replay_log.py
@@ -1,0 +1,193 @@
+"""Render an interaction-log JSONL file as a human-readable transcript.
+
+Usage:
+    python replay_log.py path/to/session.jsonl
+    cat session.jsonl | python replay_log.py -
+    python replay_log.py session.jsonl --show-state --show-messages
+
+By default state_change events and the full pre/post-truncation message lists
+inside llm_request events are suppressed for readability. Toggle with the
+--show-state and --show-messages flags.
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+
+
+def _parse_ts(ts: str) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _fmt_elapsed(start: datetime | None, ts: datetime | None) -> str:
+    if start is None or ts is None:
+        return "        "
+    secs = (ts - start).total_seconds()
+    return f"{secs:7.2f}s"
+
+
+def _truncate(text: str | None, limit: int) -> str:
+    if text is None:
+        return ""
+    text = text.replace("\n", " \\n ")
+    if limit > 0 and len(text) > limit:
+        return text[:limit - 1] + "…"
+    return text
+
+
+def _render(event: dict, start: datetime | None, args) -> list[str]:
+    """Return zero or more output lines for a single event."""
+    et = event.get("type", "?")
+    ts = _parse_ts(event.get("ts", ""))
+    pre = _fmt_elapsed(start, ts)
+
+    def line(body: str) -> str:
+        return f"{pre}  {body}"
+
+    limit = args.text_limit
+
+    if et == "session_start":
+        a = event.get("args", {})
+        return [
+            line(f"=== SESSION START  pid={event.get('pid')} commit={event.get('git_commit')}"),
+            line(f"    model={a.get('llm_model')}  lang={a.get('lang_default')}  server={a.get('server')}"),
+        ]
+
+    if et == "session_end":
+        reason = event.get("reason")
+        dur = event.get("duration_seconds")
+        out = [line(f"=== SESSION END    reason={reason}  duration={dur}s")]
+        if event.get("error_class"):
+            out.append(line(f"    ERROR {event['error_class']}: {event.get('error_message','')}"))
+        if event.get("traceback") and args.show_traceback:
+            for tline in event["traceback"].rstrip().split("\n"):
+                out.append(line(f"    {tline}"))
+        return out
+
+    if et == "face_change":
+        return [line(f"[face]   id={event.get('face_id')}  status={event.get('status')}  "
+                     f"name={event.get('name')}  lang={event.get('lang')}")]
+
+    if et == "person_resumed":
+        return [line(f"[person] resumed id={event.get('face_id')} name={event.get('name')} "
+                     f"lang={event.get('lang')} restored_msgs={event.get('restored_message_count')}")]
+
+    if et == "person_distillation":
+        return [line(f"[distill] id={event.get('face_id')} "
+                     f"name={event.get('parsed_name')} lang={event.get('parsed_lang')} "
+                     f"prefs={_truncate(event.get('parsed_preferences'), 60)}")]
+
+    if et == "transcription":
+        return [line(f"[STT]    ({event.get('language')} {event.get('language_probability', 0):.2f}) "
+                     f"{_truncate(event.get('text'), limit)}")]
+
+    if et == "stdin_command":
+        return [line(f"[stdin]  {event.get('cmd')}  {_truncate(event.get('arg'), limit)}")]
+
+    if et == "user_turn":
+        return [line(f"USER ({event.get('kind')}/{event.get('lang')}): "
+                     f"{_truncate(event.get('content'), limit)}")]
+
+    if et == "mcp_prompt":
+        return [line(f"[mcp]    {event.get('kind')} prompt (lang={event.get('lang')}): "
+                     f"{_truncate(event.get('content'), limit)}")]
+
+    if et == "llm_request":
+        out = [line(f"[llm]    -> request iter={event.get('iteration')} "
+                    f"tools={event.get('tool_count')} model={event.get('model')}")]
+        if args.show_messages:
+            for m in event.get("messages_sent", []):
+                role = m.get("role") if isinstance(m, dict) else getattr(m, "role", "?")
+                content = m.get("content") if isinstance(m, dict) else getattr(m, "content", "")
+                out.append(line(f"           {role}: {_truncate(content, limit)}"))
+        return out
+
+    if et == "llm_response":
+        out = [line(f"[llm]    <- response iter={event.get('iteration')} "
+                    f"content={_truncate(event.get('content'), limit)}")]
+        for tc in event.get("tool_calls") or []:
+            out.append(line(f"           tool_call {tc.get('name')}({_truncate(tc.get('arguments'), limit)})"))
+        return out
+
+    if et == "llm_error":
+        return [line(f"[llm]    ERROR iter={event.get('iteration')} "
+                     f"{event.get('error_class')}: {event.get('error_message')}")]
+
+    if et == "mcp_tool_call":
+        if event.get("success"):
+            return [line(f"[tool]   {event.get('name')}({_truncate(event.get('arguments'), limit)}) "
+                         f"-> {_truncate(event.get('result_text'), limit)}")]
+        return [line(f"[tool]   {event.get('name')}({_truncate(event.get('arguments'), limit)}) "
+                     f"-> ERROR {event.get('error_message')}")]
+
+    if et == "tts_speak":
+        return [line(f"BOT  ({event.get('status')}/{event.get('lang')}): "
+                     f"{_truncate(event.get('text'), limit)}")]
+
+    if et == "mute":
+        return [line(f"[mute]   muted={event.get('muted')} interrupted={event.get('interrupted_speech')}")]
+
+    if et == "state_change":
+        if not args.show_state:
+            return []
+        return [line(f"[state]  {event.get('from')} -> {event.get('to')}")]
+
+    if et == "recording_saved":
+        return [line(f"[rec]    {event.get('wav_path')}  remaining={event.get('remaining')}")]
+
+    if et == "clear_history":
+        return [line("[clear]  history cleared")]
+
+    return [line(f"[{et}]  {json.dumps({k: v for k, v in event.items() if k not in ('ts', 'type')}, ensure_ascii=False)}")]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render an interaction-log JSONL file as a transcript.")
+    parser.add_argument("path", help="Path to .jsonl log file, or '-' for stdin.")
+    parser.add_argument("--types", default=None,
+                        help="Comma-separated list of event types to include (default: all).")
+    parser.add_argument("--show-state", action="store_true",
+                        help="Include state_change events (suppressed by default).")
+    parser.add_argument("--show-messages", action="store_true",
+                        help="Dump the messages_sent list inside each llm_request event.")
+    parser.add_argument("--show-traceback", action="store_true",
+                        help="Print the full traceback string from session_end on error.")
+    parser.add_argument("--text-limit", type=int, default=300,
+                        help="Truncate text fields longer than this (0 = no truncation; default: 300).")
+    args = parser.parse_args()
+
+    type_filter = set(args.types.split(",")) if args.types else None
+    src = sys.stdin if args.path == "-" else open(args.path, "r", encoding="utf-8")
+    start_ts: datetime | None = None
+    try:
+        for raw in src:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw)
+            except json.JSONDecodeError as e:
+                print(f"!! skipping malformed line: {e}", file=sys.stderr)
+                continue
+            if start_ts is None and event.get("type") == "session_start":
+                start_ts = _parse_ts(event.get("ts", ""))
+            elif start_ts is None:
+                start_ts = _parse_ts(event.get("ts", ""))
+            if type_filter and event.get("type") not in type_filter:
+                continue
+            for output_line in _render(event, start_ts, args):
+                print(output_line)
+    finally:
+        if src is not sys.stdin:
+            src.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcpclient_speech/windowmgr.py
+++ b/mcpclient_speech/windowmgr.py
@@ -180,6 +180,7 @@ class WindowMgr:
         mpl.rcParams['keymap.yscale'] = []
         mpl.rcParams['keymap.grid'] = []
         mpl.rcParams['keymap.grid_minor'] = []
+        mpl.rcParams['keymap.save'] = []
 
     def start_event_loop(self):
         self.add_close_callback(self.exit_event_loop)


### PR DESCRIPTION
- **mcpclient_speech**: central `config.toml` + `--config` flag, default config shipped, README rewritten, unknown-key warnings.
- **face client**: space flushes listen, `m` cancels in-flight listen/TTS, MUTED stays visible across transitions, `s` saves the next N raw VAD recordings to `recordings/`, TTS poll tolerates a failed audio device.
- **record.py**: drop hardcoded mic fallback, use system default.
- **candytron_mcp**: `check_event` now paces `--no-window` / `--simulate-camera` modes (was pegging a CPU core).