### PR TITLE
people_memory: make the `similar` CLI work with the ArcFace db

### DIFF
--- a/face/README.md
+++ b/face/README.md
@@ -50,9 +50,32 @@ All modules use events.py for publish/subscribe communication.
 ### Stable person IDs
 
 People are identified by a stable `person_id` (e.g. `p001`) that never changes,
-even on rename. The face database (`known_faces/faces.pkl`) stores person IDs,
+even on rename. The face database (`known_faces/faces_arcface.pkl` for the default
+InsightFace backend, `faces.pkl` for the legacy dlib backend) stores person IDs,
 not names. Display names live in `people/{person_id}.json` and are the single
 source of truth.
+
+### Face recognition backend
+
+Detection and embedding run through a pluggable backend, selected by
+`[tracker] backend` in `face_config.toml`:
+
+- **`insightface`** (default) -- SCRFD detector + ArcFace 512-d embedder on
+  onnxruntime, compared with cosine distance. Far more robust at distance and
+  off-angle. The `buffalo_l` model pack (~300 MB) downloads automatically to
+  `~/.insightface/models` on first run. Providers auto-select CUDA → CoreML →
+  CPU; for CUDA on Nvidia, install `onnxruntime-gpu` instead of `onnxruntime`.
+- **`dlib`** -- the legacy HOG detector + 128-d encoder, Euclidean distance.
+  Kept as a fallback / A-B comparison.
+
+The two embedding spaces are incompatible, so each backend keeps its own db file
+(`faces_arcface.pkl` vs `faces.pkl`) and they never clobber each other. To carry
+existing people over to the InsightFace backend without re-meeting anyone,
+re-embed the saved face crops:
+
+```
+uv run python migrate_db.py --db-dir known_faces
+```
 
 ### Single facts storage
 
@@ -202,7 +225,8 @@ pause / resume             Pause/resume speech listening
 
 ```
 known_faces/
-  faces.pkl              Face encodings keyed by person_id (schema v2)
+  faces_arcface.pkl      InsightFace/ArcFace 512-d encodings, cosine (schema v3, default)
+  faces.pkl              Legacy dlib 128-d encodings, Euclidean (schema v2, dlib backend)
   p001/                  Face images for person p001
     20260410_143022.jpg
   p002/

--- a/face/agent.py
+++ b/face/agent.py
@@ -861,13 +861,12 @@ def main():
                         datefmt="%H:%M:%S")
 
     # Initialize all components
-    face_db = FaceDatabase(db_dir=args.db_dir)
+    from face_config import build_db_kwargs, build_tracker_kwargs
+    face_db = FaceDatabase(db_dir=args.db_dir, **build_db_kwargs())
     face_db.load()
     emotion_detector = EmotionDetector()
-    from face_config import get_tracker_config
-    _tc = get_tracker_config()
     tracker = FaceTracker(db=face_db, emotion_detector=emotion_detector,
-                          max_missing_seconds=_tc.get("max_missing_seconds", 3.0))
+                          **build_tracker_kwargs())
 
     voice_in = VoiceInput()
     voice_out = VoiceOutput(model_name=args.en_voice)

--- a/face/face_config.py
+++ b/face/face_config.py
@@ -24,3 +24,33 @@ _CONFIG = _load_config()
 
 def get_tracker_config() -> dict:
     return _CONFIG.get("tracker", {})
+
+
+# Map [tracker] config keys -> FaceTracker / FaceDatabase constructor kwargs.
+# Only keys actually present in the TOML are forwarded, so the dataclass/
+# constructor defaults remain the single source of truth for anything unset.
+_DB_KEYS = {
+    "recognition_tolerance": "tolerance",
+    "recognition_k": "recognition_k",
+}
+_TRACKER_KEYS = {
+    "frame_scale": "frame_scale",
+    "max_missing_seconds": "max_missing_seconds",
+    "focus_min_area_frac": "focus_min_area_frac",
+    "focus_dwell_seconds": "focus_dwell_seconds",
+    "enroll_min_face_px": "enroll_min_face_px",
+    "enroll_min_sharpness": "enroll_min_sharpness",
+    "enroll_frontal_tolerance": "enroll_frontal_tolerance",
+}
+
+
+def build_db_kwargs() -> dict:
+    """FaceDatabase kwargs from [tracker] config (present keys only)."""
+    tc = get_tracker_config()
+    return {kw: tc[key] for key, kw in _DB_KEYS.items() if key in tc}
+
+
+def build_tracker_kwargs() -> dict:
+    """FaceTracker kwargs from [tracker] config (present keys only)."""
+    tc = get_tracker_config()
+    return {kw: tc[key] for key, kw in _TRACKER_KEYS.items() if key in tc}

--- a/face/face_config.py
+++ b/face/face_config.py
@@ -34,7 +34,11 @@ _DB_KEYS = {
     "recognition_k": "recognition_k",
 }
 _TRACKER_KEYS = {
+    "backend": "backend",
     "frame_scale": "frame_scale",
+    "det_size": "det_size",
+    "det_thresh": "det_thresh",
+    "providers": "providers",
     "max_missing_seconds": "max_missing_seconds",
     "focus_min_area_frac": "focus_min_area_frac",
     "focus_dwell_seconds": "focus_dwell_seconds",
@@ -44,10 +48,26 @@ _TRACKER_KEYS = {
 }
 
 
+def backend_metric(backend: str) -> str:
+    """Embedding comparison metric implied by a backend name.
+
+    dlib's 128-d encodings compare under Euclidean distance; InsightFace's
+    L2-normalized ArcFace embeddings under cosine. The db file and schema version
+    follow from this, so it must be set on FaceDatabase before load().
+    """
+    return "euclidean" if backend == "dlib" else "cosine"
+
+
 def build_db_kwargs() -> dict:
-    """FaceDatabase kwargs from [tracker] config (present keys only)."""
+    """FaceDatabase kwargs from [tracker] config (present keys only).
+
+    The comparison metric is derived from the configured backend so the db opens
+    the matching file (faces.pkl vs faces_arcface.pkl) at load() time.
+    """
     tc = get_tracker_config()
-    return {kw: tc[key] for key, kw in _DB_KEYS.items() if key in tc}
+    kwargs = {kw: tc[key] for key, kw in _DB_KEYS.items() if key in tc}
+    kwargs["metric"] = backend_metric(tc.get("backend", "insightface"))
+    return kwargs
 
 
 def build_tracker_kwargs() -> dict:

--- a/face/face_config.toml
+++ b/face/face_config.toml
@@ -1,5 +1,41 @@
 [tracker]
+# Shared face-tracker tuning, read by face/agent.py, the standalone
+# face_tracker.py, and mcpclient_speech/mcpclient_speech_face.py.
+# Any value left out here falls back to the constructor default in
+# face_tracker.py. CLI flags (where provided) override these.
+
+# --- Detection ---
+# Fraction the frame is downscaled before detection. Higher = more pixels
+# reach the encoder (better on small/distant faces) at higher CPU cost.
+frame_scale = 0.75
+
+# --- Recognition (Group 1: fewer confusions / misses) ---
+# Max embedding distance to accept a match. Lower = stricter (fewer
+# confusions), higher = looser (fewer misses). dlib's loose default is 0.6.
+recognition_tolerance = 0.5
+# Score each candidate person by the mean of their k nearest stored samples
+# instead of a single nearest encoding. k=1 = old behaviour.
+recognition_k = 3
+
+# --- Track persistence (Group 2: survive brief look-aways) ---
 # Grace period (seconds) before a missing face becomes FACE_DISAPPEARED.
 # Brief head-turns / occlusions within this window emit FACE_OCCLUDED /
-# FACE_RECOVERED instead.
-max_missing_seconds = 3.0
+# FACE_RECOVERED instead, and the face keeps its identity on return.
+max_missing_seconds = 8.0
+
+# --- Enrollment quality gate (Group 1: stop poisoning the DB) ---
+# Auto-enrollment only fires when the face passes all of these.
+# enroll_min_face_px:        min bbox side in full-frame pixels (0 = off)
+# enroll_min_sharpness:      min variance-of-Laplacian, rejects blur (0 = off)
+# enroll_frontal_tolerance:  max |nose-offset - 0.5| between the eyes;
+#                            lower = stricter frontal requirement (1.0 = off)
+enroll_min_face_px = 80
+enroll_min_sharpness = 40.0
+enroll_frontal_tolerance = 0.18
+
+# --- Engagement / "makes contact" focus gate (Group 3, no gaze yet) ---
+# A face must cover at least this fraction of the frame (proximity) and be
+# held steady this many seconds before it can take focus -- filters people
+# passing by in the background. 0 = off (instant, any size).
+focus_min_area_frac = 0.04
+focus_dwell_seconds = 1.0

--- a/face/face_config.toml
+++ b/face/face_config.toml
@@ -4,15 +4,34 @@
 # Any value left out here falls back to the constructor default in
 # face_tracker.py. CLI flags (where provided) override these.
 
-# --- Detection ---
-# Fraction the frame is downscaled before detection. Higher = more pixels
-# reach the encoder (better on small/distant faces) at higher CPU cost.
+# --- Detection / embedding backend ---
+# "insightface" = SCRFD detector + ArcFace 512-d embedder on onnxruntime
+# (cosine metric, far better at distance/angle). "dlib" = legacy HOG + 128-d
+# encoder (Euclidean metric). The two embedding spaces are incompatible; the
+# face db (faces.pkl, schema v3 = InsightFace) is tied to the backend, so
+# switching to "dlib" needs a matching v2 db. Kept as a fallback / A-B switch.
+backend = "insightface"
+
+# InsightFace detector input size (square). Larger = better on small/distant
+# faces, slower. 640 is the model default. (Ignored by the dlib backend.)
+det_size = 640
+# Minimum detector confidence to keep a face.
+det_thresh = 0.5
+# Onnxruntime execution providers, best-available first. Leave unset to
+# auto-pick CUDA -> CoreML -> CPU. Set explicitly to pin, e.g.
+# providers = ["CPUExecutionProvider"]. Always filtered to what's installed.
+# providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+# Fraction the frame is downscaled before detection. dlib backend only;
+# InsightFace uses det_size instead.
 frame_scale = 0.75
 
 # --- Recognition (Group 1: fewer confusions / misses) ---
 # Max embedding distance to accept a match. Lower = stricter (fewer
-# confusions), higher = looser (fewer misses). dlib's loose default is 0.6.
-recognition_tolerance = 0.5
+# confusions), higher = looser (fewer misses). This is a COSINE distance for
+# the InsightFace backend (typical match < ~0.4); the dlib backend wants a
+# Euclidean value instead (~0.5). Tune empirically against the real room.
+recognition_tolerance = 0.4
 # Score each candidate person by the mean of their k nearest stored samples
 # instead of a single nearest encoding. k=1 = old behaviour.
 recognition_k = 3

--- a/face/face_tracker.py
+++ b/face/face_tracker.py
@@ -48,6 +48,51 @@ EMOTION_LABELS = ["neutral", "happy", "surprise", "sad", "angry", "disgust", "fe
 
 
 # ---------------------------------------------------------------------------
+# Embedding distance helpers
+# ---------------------------------------------------------------------------
+
+def _embedding_distances(known, encoding, metric: str) -> np.ndarray:
+    """Distance from ``encoding`` to each row of ``known`` under ``metric``.
+
+    ``"euclidean"`` is the legacy dlib metric (L2 on 128-d vectors).
+    ``"cosine"`` (``1 - cos``) is correct for L2-normalized ArcFace embeddings;
+    for unit vectors the cosine similarity is just the dot product.
+    """
+    known = np.asarray(known, dtype=np.float64)
+    enc = np.asarray(encoding, dtype=np.float64)
+    if metric == "cosine":
+        return 1.0 - known @ enc
+    return np.linalg.norm(known - enc, axis=1)
+
+
+def _pair_distance(a, b, metric: str) -> float:
+    """Distance between two single embeddings under ``metric``."""
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    if metric == "cosine":
+        return float(1.0 - np.dot(a, b))
+    return float(np.linalg.norm(a - b))
+
+
+def _select_providers(override=None) -> list:
+    """Pick onnxruntime execution providers, best-available first.
+
+    Preference CUDA (Nvidia) -> CoreML (Apple Silicon) -> CPU, intersected with
+    what this onnxruntime build actually exposes. ``override`` (from config) is
+    honoured but still filtered to available providers so a GPU-less machine
+    never fails to start.
+    """
+    available = set(ort.get_available_providers())
+    if override:
+        chosen = [p for p in override if p in available]
+        return chosen or ["CPUExecutionProvider"]
+    preferred = ["CUDAExecutionProvider", "CoreMLExecutionProvider",
+                 "CPUExecutionProvider"]
+    chosen = [p for p in preferred if p in available]
+    return chosen or ["CPUExecutionProvider"]
+
+
+# ---------------------------------------------------------------------------
 # Event types and payloads
 # ---------------------------------------------------------------------------
 
@@ -215,34 +260,73 @@ class Identity:
 # ---------------------------------------------------------------------------
 
 class FaceDatabase:
-    """Persistent face encoding database keyed by stable person_id."""
+    """Persistent face encoding database keyed by stable person_id.
 
-    SCHEMA_VERSION = 2
+    ``metric`` selects how stored embeddings are compared:
+    ``"euclidean"`` for the legacy dlib 128-d encodings (schema v2) and
+    ``"cosine"`` for the L2-normalized InsightFace/ArcFace 512-d embeddings
+    (schema v3). The two are not interchangeable, so each metric uses its own
+    db file (``faces.pkl`` for dlib/v2, ``faces_arcface.pkl`` for InsightFace/v3):
+    the backends coexist for A/B comparison and one never clobbers the other's
+    saved encodings. ``load()`` still refuses a file whose ``schema_version``
+    does not match, warning and starting empty rather than mixing dimensions.
+    """
+
+    # Per-metric db file and the schema version it must carry.
+    _DB_FILE = {"euclidean": "faces.pkl", "cosine": "faces_arcface.pkl"}
+    _SCHEMA = {"euclidean": 2, "cosine": 3}
 
     def __init__(self, db_dir: str = _KNOWN_FACES_DIR, tolerance: float = 0.6,
-                 recognition_k: int = 3):
+                 recognition_k: int = 3, metric: str = "cosine"):
         self.db_dir = db_dir
         self.tolerance = tolerance
+        self.metric = metric
         # Number of nearest stored samples per person to average when matching.
         # k=1 reproduces the old single-nearest behaviour; k>1 makes a single
         # lucky-close (or poisoned) sample less able to win a false match.
         self.recognition_k = max(1, recognition_k)
-        self._db = {
+        self._db = self._empty_db()
+        self._lock = threading.Lock()
+
+    @property
+    def schema_version(self) -> int:
+        return self._SCHEMA[self.metric]
+
+    @property
+    def db_file(self) -> str:
+        return os.path.join(self.db_dir, self._DB_FILE[self.metric])
+
+    def _empty_db(self) -> dict:
+        return {
             "encodings": [],
             "person_ids": [],
             "last_seen": {},
-            "schema_version": self.SCHEMA_VERSION,
+            "schema_version": self.schema_version,
         }
-        self._lock = threading.Lock()
 
     def load(self):
-        db_file = os.path.join(self.db_dir, "faces.pkl")
+        db_file = self.db_file
         if os.path.exists(db_file):
             with open(db_file, "rb") as f:
-                self._db = pickle.load(f)
-            self._db.setdefault("last_seen", {})
-            self._db.setdefault("person_ids", [])
-            self._db.setdefault("schema_version", self.SCHEMA_VERSION)
+                loaded = pickle.load(f)
+            version = loaded.get("schema_version", 2)
+            if version != self.schema_version:
+                # The file holds embeddings of the wrong dimension/metric for the
+                # active backend. Refuse to mix: warn and start empty so
+                # auto-enroll can repopulate. For the InsightFace backend, run
+                # migrate_db.py to re-embed the saved face crops without losing
+                # anyone.
+                logger.warning(
+                    "Ignoring face db at %s: schema v%s != expected v%s. "
+                    "Starting empty -- run migrate_db.py to re-embed known_faces/.",
+                    db_file, version, self.schema_version,
+                )
+                self._db = self._empty_db()
+            else:
+                self._db = loaded
+                self._db.setdefault("last_seen", {})
+                self._db.setdefault("person_ids", [])
+                self._db.setdefault("schema_version", self.schema_version)
         logger.info(
             f"Database loaded: {len(self.known_person_ids)} people, "
             f"{self.encoding_count} encodings"
@@ -250,16 +334,16 @@ class FaceDatabase:
 
     def save(self):
         os.makedirs(self.db_dir, exist_ok=True)
-        db_file = os.path.join(self.db_dir, "faces.pkl")
         with self._lock:
-            with open(db_file, "wb") as f:
+            with open(self.db_file, "wb") as f:
                 pickle.dump(self._db, f)
 
     def recognize(self, encoding: np.ndarray) -> tuple:
         with self._lock:
             if not self._db["encodings"]:
                 return (None, 0.0)
-            distances = face_recognition.face_distance(self._db["encodings"], encoding)
+            distances = _embedding_distances(
+                self._db["encodings"], encoding, self.metric)
             # Aggregate per person: score each candidate by the mean of their
             # k nearest stored samples, then pick the closest person. This is
             # steadier than a single nearest encoding -- one good sample can no
@@ -288,6 +372,16 @@ class FaceDatabase:
         self._save_face_image(person_id, frame, bbox)
         logger.info(f"Added face for {person_id!r} ({sample_count} samples)")
 
+    def add_encoding(self, person_id: str, encoding: np.ndarray):
+        """Append one encoding without persisting or saving a crop.
+
+        For bulk/migration use (e.g. migrate_db.py rebuilding the db from saved
+        face crops); call ``save()`` once after adding everything.
+        """
+        with self._lock:
+            self._db["encodings"].append(np.asarray(encoding, dtype=np.float64))
+            self._db["person_ids"].append(person_id)
+
     def update_last_seen(self, person_id: str):
         with self._lock:
             self._db["last_seen"][person_id] = datetime.now().timestamp()
@@ -297,12 +391,7 @@ class FaceDatabase:
 
     def clear(self):
         with self._lock:
-            self._db = {
-                "encodings": [],
-                "person_ids": [],
-                "last_seen": {},
-                "schema_version": self.SCHEMA_VERSION,
-            }
+            self._db = self._empty_db()
         self.save()
         logger.info("Database cleared")
 
@@ -325,6 +414,50 @@ class FaceDatabase:
             self.save()
             logger.info(f"Removed {removed} encodings for {person_id!r}")
         return removed
+
+    def rename_person(self, old_id: str, new_id: str) -> int:
+        """Reassign all of ``old_id``'s encodings and saved crops to ``new_id``.
+
+        Merges into ``new_id`` if it already exists. Returns the number of
+        encodings moved; a no-op (0) when the ids match or ``old_id`` is absent.
+        Used when a face that was auto-enrolled as ``pNNN`` is later given a name,
+        so the two never coexist as competing identities.
+        """
+        if old_id == new_id:
+            return 0
+        with self._lock:
+            moved = 0
+            for i, pid in enumerate(self._db["person_ids"]):
+                if pid == old_id:
+                    self._db["person_ids"][i] = new_id
+                    moved += 1
+            if old_id in self._db["last_seen"]:
+                ts = self._db["last_seen"].pop(old_id)
+                self._db["last_seen"][new_id] = max(
+                    self._db["last_seen"].get(new_id, 0.0), ts)
+        if moved:
+            self.save()
+            self._move_face_images(old_id, new_id)
+            logger.info(f"Renamed {old_id!r} -> {new_id!r} ({moved} encodings)")
+        return moved
+
+    def _move_face_images(self, old_id: str, new_id: str):
+        old_dir = os.path.join(self.db_dir, old_id)
+        if not os.path.isdir(old_dir):
+            return
+        new_dir = os.path.join(self.db_dir, new_id)
+        os.makedirs(new_dir, exist_ok=True)
+        for fname in os.listdir(old_dir):
+            src = os.path.join(old_dir, fname)
+            dst = os.path.join(new_dir, fname)
+            if os.path.exists(dst):  # avoid clobbering on merge
+                base, ext = os.path.splitext(fname)
+                dst = os.path.join(new_dir, f"{base}_{old_id}{ext}")
+            os.rename(src, dst)
+        try:
+            os.rmdir(old_dir)
+        except OSError:
+            pass
 
     @property
     def known_person_ids(self) -> set:
@@ -379,6 +512,89 @@ class EmotionDetector:
 
 
 # ---------------------------------------------------------------------------
+# Detection / embedding backends
+# ---------------------------------------------------------------------------
+
+class DlibBackend:
+    """Legacy backend: dlib HOG detector + 128-d encoder via face_recognition.
+
+    Faces are detected on a downscaled frame (``frame_scale``) for speed, then
+    the bboxes are scaled back to full-frame coordinates. Embeddings compare
+    under the Euclidean metric.
+    """
+
+    name = "dlib"
+    metric = "euclidean"
+
+    def __init__(self, frame_scale: float = 0.5):
+        self.frame_scale = frame_scale
+
+    def detect(self, frame):
+        s = self.frame_scale
+        small = cv2.resize(frame, (0, 0), fx=s, fy=s)
+        rgb_small = cv2.cvtColor(small, cv2.COLOR_BGR2RGB)
+        locations = face_recognition.face_locations(rgb_small)
+        encodings = face_recognition.face_encodings(rgb_small, locations)
+        locations = [
+            (int(t / s), int(r / s), int(b / s), int(l / s))
+            for t, r, b, l in locations
+        ]
+        return locations, encodings
+
+
+class InsightFaceBackend:
+    """InsightFace backend: SCRFD detector + ArcFace 512-d embedder on onnxruntime.
+
+    One ``FaceAnalysis.get(frame)`` pass per frame yields bbox, det_score, 5-point
+    kps, head pose, and an L2-normalized 512-d embedding for every face. The model
+    takes BGR directly (no RGB conversion) and returns bboxes as ``[x1,y1,x2,y2]``,
+    which we map to the tracker's ``(top,right,bottom,left)`` convention.
+    Embeddings are unit-norm, so they compare under the cosine metric.
+
+    The ``buffalo_l`` pack (~300 MB) is downloaded by InsightFace on first use to
+    ``~/.insightface/models``; expect a one-time cold start.
+    """
+
+    name = "insightface"
+    metric = "cosine"
+
+    def __init__(self, det_size=640, det_thresh: float = 0.5, providers=None,
+                 model_name: str = "buffalo_l"):
+        from insightface.app import FaceAnalysis
+
+        if isinstance(det_size, (int, float)):
+            det_size = (int(det_size), int(det_size))
+        else:
+            det_size = (int(det_size[0]), int(det_size[1]))
+        providers = _select_providers(providers)
+        # ctx_id selects the CUDA device; -1 forces CPU. CoreML/CPU ignore it.
+        ctx_id = 0 if "CUDAExecutionProvider" in providers else -1
+        logger.info("InsightFace backend: model=%s providers=%s det_size=%s",
+                    model_name, providers, det_size)
+        self.app = FaceAnalysis(name=model_name, providers=providers)
+        self.app.prepare(ctx_id=ctx_id, det_size=det_size, det_thresh=det_thresh)
+        # Latest per-detection extras (kps/pose/det_score), aligned with the
+        # returned detection order. Stashed for the deferred head-pose engagement
+        # work; not consumed yet.
+        self.last_extras: list = []
+
+    def detect(self, frame):
+        faces = self.app.get(frame)
+        locations, encodings, extras = [], [], []
+        for f in faces:
+            x1, y1, x2, y2 = (int(v) for v in f.bbox)
+            locations.append((y1, x2, y2, x1))  # (top, right, bottom, left)
+            encodings.append(np.asarray(f.normed_embedding, dtype=np.float64))
+            extras.append({
+                "kps": getattr(f, "kps", None),
+                "pose": getattr(f, "pose", None),
+                "det_score": float(getattr(f, "det_score", 0.0)),
+            })
+        self.last_extras = extras
+        return locations, encodings
+
+
+# ---------------------------------------------------------------------------
 # FaceTracker
 # ---------------------------------------------------------------------------
 
@@ -395,8 +611,12 @@ class FaceTracker:
     def __init__(self,
                  db: FaceDatabase,
                  emotion_detector: EmotionDetector,
+                 backend: str = "insightface",
                  frame_scale: float = 0.5,
-                 track_encoding_threshold: float = 0.5,
+                 det_size=640,
+                 det_thresh: float = 0.5,
+                 providers=None,
+                 track_encoding_threshold: Optional[float] = None,
                  track_iou_threshold: float = 0.3,
                  max_missing_seconds: float = 2.0,
                  recognition_confirm_seconds: float = 0.15,
@@ -414,6 +634,35 @@ class FaceTracker:
         self.db = db
         self.emotion_detector = emotion_detector
         self.frame_scale = frame_scale
+
+        # Detection/embedding backend. dlib stays available as a fallback so the
+        # two can be A/B compared by flipping [tracker] backend in config.
+        if backend == "dlib":
+            self._backend = DlibBackend(frame_scale=frame_scale)
+        elif backend == "insightface":
+            self._backend = InsightFaceBackend(
+                det_size=det_size, det_thresh=det_thresh, providers=providers)
+        else:
+            raise ValueError(f"Unknown backend {backend!r} (expected 'insightface' or 'dlib')")
+        self._metric = self._backend.metric
+        # The db's metric must already match the backend: it picks the db file and
+        # schema version at load() time, which ran before this tracker was built.
+        # A mismatch means the wrong db file was loaded -- realign and warn rather
+        # than silently comparing embeddings across metrics.
+        if self.db.metric != self._metric:
+            logger.warning(
+                "FaceDatabase metric %r != backend %r metric %r; realigning. "
+                "Build FaceDatabase with metric=backend_metric(backend) so the "
+                "right db file is loaded.",
+                self.db.metric, self._backend.name, self._metric,
+            )
+            self.db.metric = self._metric
+
+        # Frame-to-frame association threshold. Same identity across adjacent
+        # frames sits very close in either metric; the sensible cutoff differs by
+        # metric, so resolve a default only when the caller did not set one.
+        if track_encoding_threshold is None:
+            track_encoding_threshold = 0.6 if self._metric == "cosine" else 0.5
         self._track_enc_thresh = track_encoding_threshold
         self._track_iou_thresh = track_iou_threshold
         self._max_missing_s = max_missing_seconds
@@ -429,6 +678,11 @@ class FaceTracker:
 
         self._tracks: list[TrackedFace] = []
         self._identities: dict[int, Identity] = {}
+        # Track ids that have already been enrolled or named, so they are never
+        # auto-enrolled a second time. A track keeps its physical identity; if
+        # recognition briefly drops (revoking the Identity), we must re-recognize
+        # it -- not mint a competing new pNNN, which causes id flip-flop.
+        self._enrolled_track_ids: set[int] = set()
         self._last_frames: dict[int, np.ndarray] = {}
         self._next_id = 1
         self._lock = threading.Lock()
@@ -559,6 +813,7 @@ class FaceTracker:
                 ident = self._identities.pop(track.track_id, None)
                 self._emotion_stable.pop(track.track_id, None)
                 self._last_frames.pop(track.track_id, None)
+                self._enrolled_track_ids.discard(track.track_id)
                 pending.append(self._make_event(
                     FaceEventType.FACE_DISAPPEARED, track.track_id,
                     FaceDisappearedPayload(
@@ -676,8 +931,25 @@ class FaceTracker:
         face = self.get_face_by_id(track_id)
         if face is None:
             return False
+        # If this track is already bound to another id (typically an auto-enrolled
+        # pNNN), rename that id to the new label rather than adding a second,
+        # competing identity for the same face -- otherwise recognition keeps
+        # flip-flopping between the two ids frame to frame.
+        with self._lock:
+            existing = self._identities.get(track_id)
+            old_pid = existing.person_id if existing else None
+        if old_pid and old_pid != person_id:
+            self.db.rename_person(old_pid, person_id)
+            with self._lock:
+                # Repoint any in-memory identities that referenced the old id.
+                for ident in self._identities.values():
+                    if ident.person_id == old_pid:
+                        ident.person_id = person_id
+                    if ident._candidate_person_id == old_pid:
+                        ident._candidate_person_id = person_id
         self.db.add_face(person_id, face.last_encoding, frame, face.bbox)
         with self._lock:
+            self._enrolled_track_ids.add(track_id)
             self._identities[track_id] = Identity(
                 person_id=person_id, confidence=100.0,
                 _matching_since=0.0, _confirmed=True,
@@ -707,6 +979,10 @@ class FaceTracker:
         for track in self._tracks:
             if track.track_id in self._identities:
                 continue
+            # Already enrolled/named once: never mint a competing id, even if its
+            # identity was just revoked by a momentary recognition miss.
+            if track.track_id in self._enrolled_track_ids:
+                continue
             if not track.is_visible:
                 continue
             if track.frames_visible < self._enroll_min_frames:
@@ -719,6 +995,7 @@ class FaceTracker:
             person_id = self._allocate_person_id()
             # Enroll the clean raw encoding, not the EMA-smoothed tracking one.
             self.db.add_face(person_id, track.last_encoding, frame, track.bbox)
+            self._enrolled_track_ids.add(track.track_id)
             self._identities[track.track_id] = Identity(
                 person_id=person_id, confidence=100.0,
                 _matching_since=0.0, _confirmed=True,
@@ -920,16 +1197,7 @@ class FaceTracker:
         return events
 
     def _detect_faces(self, frame):
-        small = cv2.resize(frame, (0, 0), fx=self.frame_scale, fy=self.frame_scale)
-        rgb_small = cv2.cvtColor(small, cv2.COLOR_BGR2RGB)
-        locations = face_recognition.face_locations(rgb_small)
-        encodings = face_recognition.face_encodings(rgb_small, locations)
-        s = self.frame_scale
-        locations = [
-            (int(t / s), int(r / s), int(b / s), int(l / s))
-            for t, r, b, l in locations
-        ]
-        return locations, encodings
+        return self._backend.detect(frame)
 
     def _match(self, detections):
         if not detections or not self._tracks:
@@ -940,7 +1208,7 @@ class FaceTracker:
         costs = np.zeros((n_det, n_trk))
         for i, (bbox_d, enc_d) in enumerate(detections):
             for j, track in enumerate(self._tracks):
-                costs[i, j] = np.linalg.norm(enc_d - track.encoding)
+                costs[i, j] = _pair_distance(enc_d, track.encoding, self._metric)
 
         matches = []
         used_dets = set()
@@ -986,6 +1254,12 @@ class FaceTracker:
         now = time.time()
         track.last_encoding = encoding
         track.encoding = 0.3 * encoding + 0.7 * track.encoding
+        if self._metric == "cosine":
+            # The EMA blend of two unit vectors is no longer unit-norm; cosine
+            # distance assumes unit vectors, so re-normalize.
+            norm = np.linalg.norm(track.encoding)
+            if norm > 0:
+                track.encoding = track.encoding / norm
         track.bbox = bbox
         track.last_seen = now
         track.frames_visible += 1
@@ -1213,6 +1487,18 @@ def main():
             msg = f"{p.old_track_id} -> {p.new_track_id} ({p.new_person_id or '?'})"
         elif event.type == FaceEventType.IDENTITY_CONFIRMED:
             msg = f"track={event.track_id} -> {p.person_id} ({p.confidence:.0f}%)"
+        elif event.type == FaceEventType.IDENTITY_CHANGED:
+            msg = f"track={event.track_id} {p.old_person_id} -> {p.new_person_id} ({p.new_confidence:.0f}%)"
+        elif event.type == FaceEventType.IDENTITY_LOST:
+            msg = f"track={event.track_id} lost {p.previous_person_id}"
+        elif event.type == FaceEventType.FACE_LEARNED:
+            msg = f"track={event.track_id} learned as {p.person_id}"
+        elif event.type == FaceEventType.FACE_ENROLLED:
+            msg = f"track={event.track_id} enrolled as {p.person_id}"
+        elif event.type == FaceEventType.FACE_OCCLUDED:
+            msg = f"track={event.track_id} id={p.person_id or '?'}"
+        elif event.type == FaceEventType.FACE_RECOVERED:
+            msg = f"track={event.track_id} id={p.person_id or '?'} missing={p.seconds_missing:.1f}s"
         elif event.type == FaceEventType.EMOTION_CHANGED:
             msg = f"track={event.track_id} {p.old_emotion}->{p.new_emotion}"
         else:

--- a/face/face_tracker.py
+++ b/face/face_tracker.py
@@ -1463,8 +1463,14 @@ def main():
     parser = argparse.ArgumentParser(description="Standalone face tracker")
     parser.add_argument("--db-dir", default="known_faces", help="Face database directory")
     parser.add_argument("--camera", type=int, default=0, help="Camera index")
+    parser.add_argument("--backend", choices=["insightface", "dlib"], default=None,
+                        help="Detection/embedding backend (overrides face_config.toml)")
+    parser.add_argument("--det-size", type=int, default=None,
+                        help="InsightFace detector input size (square)")
+    parser.add_argument("--det-thresh", type=float, default=None,
+                        help="InsightFace minimum detector confidence")
     parser.add_argument("--scale", type=float, default=None,
-                        help="Detection scale factor (overrides face_config.toml)")
+                        help="dlib backend detection scale factor (overrides face_config.toml)")
     parser.add_argument("--fps", type=int, default=0, help="Max FPS (0 = unlimited)")
     parser.add_argument("--no-emotion", action="store_true", help="Disable emotion detection")
     parser.add_argument("--no-log-window", action="store_true", help="Disable log window")
@@ -1505,8 +1511,13 @@ def main():
             msg = str(p)[:60]
         log_lines.append((ts, event.type.name, msg))
 
-    from face_config import build_db_kwargs, build_tracker_kwargs
-    face_db = FaceDatabase(db_dir=args.db_dir, **build_db_kwargs())
+    from face_config import build_db_kwargs, build_tracker_kwargs, backend_metric
+    db_kwargs = build_db_kwargs()
+    if args.backend is not None:
+        # Keep the db's metric/file in step with a CLI backend override so
+        # load() opens the matching db (it runs before the tracker is built).
+        db_kwargs["metric"] = backend_metric(args.backend)
+    face_db = FaceDatabase(db_dir=args.db_dir, **db_kwargs)
     face_db.load()
 
     emotion_detector = None
@@ -1514,8 +1525,14 @@ def main():
         emotion_detector = EmotionDetector()
 
     tracker_kwargs = build_tracker_kwargs()
-    if args.scale is not None:
-        tracker_kwargs["frame_scale"] = args.scale
+    for cli_val, kw in (
+        (args.backend, "backend"),
+        (args.det_size, "det_size"),
+        (args.det_thresh, "det_thresh"),
+        (args.scale, "frame_scale"),
+    ):
+        if cli_val is not None:
+            tracker_kwargs[kw] = cli_val
     tracker = FaceTracker(db=face_db, emotion_detector=emotion_detector,
                           **tracker_kwargs)
     tracker.subscribe(on_event_display)

--- a/face/face_tracker.py
+++ b/face/face_tracker.py
@@ -172,6 +172,10 @@ class TrackedFace:
     emotion: str = "neutral"
     emotion_confidence: float = 0.0
     encoding: np.ndarray = field(default_factory=lambda: np.zeros(128))
+    # Most recent *raw* detection encoding (before the EMA blend in `encoding`).
+    # Used for enrollment so we store a clean single-frame embedding, never the
+    # smoothed-and-possibly-contaminated tracking encoding.
+    last_encoding: np.ndarray = field(default_factory=lambda: np.zeros(128))
     bbox: tuple = (0, 0, 0, 0)  # (top, right, bottom, left)
     first_seen: float = 0.0
     last_seen: float = 0.0
@@ -215,9 +219,14 @@ class FaceDatabase:
 
     SCHEMA_VERSION = 2
 
-    def __init__(self, db_dir: str = _KNOWN_FACES_DIR, tolerance: float = 0.6):
+    def __init__(self, db_dir: str = _KNOWN_FACES_DIR, tolerance: float = 0.6,
+                 recognition_k: int = 3):
         self.db_dir = db_dir
         self.tolerance = tolerance
+        # Number of nearest stored samples per person to average when matching.
+        # k=1 reproduces the old single-nearest behaviour; k>1 makes a single
+        # lucky-close (or poisoned) sample less able to win a false match.
+        self.recognition_k = max(1, recognition_k)
         self._db = {
             "encodings": [],
             "person_ids": [],
@@ -251,12 +260,22 @@ class FaceDatabase:
             if not self._db["encodings"]:
                 return (None, 0.0)
             distances = face_recognition.face_distance(self._db["encodings"], encoding)
-            best_idx = np.argmin(distances)
-            best_dist = distances[best_idx]
-            if best_dist < self.tolerance:
-                person_id = self._db["person_ids"][best_idx]
+            # Aggregate per person: score each candidate by the mean of their
+            # k nearest stored samples, then pick the closest person. This is
+            # steadier than a single nearest encoding -- one good sample can no
+            # longer pull a confusion across the line on its own.
+            by_pid: dict[str, list[float]] = {}
+            for dist, pid in zip(distances, self._db["person_ids"]):
+                by_pid.setdefault(pid, []).append(float(dist))
+            best_pid, best_dist = None, float("inf")
+            for pid, dists in by_pid.items():
+                dists.sort()
+                score = float(np.mean(dists[:self.recognition_k]))
+                if score < best_dist:
+                    best_dist, best_pid = score, pid
+            if best_pid is not None and best_dist < self.tolerance:
                 confidence = max(0.0, 1.0 - best_dist) * 100
-                return (person_id, confidence)
+                return (best_pid, confidence)
             return (None, 0.0)
 
     def add_face(self, person_id: str, encoding: np.ndarray,
@@ -384,9 +403,14 @@ class FaceTracker:
                  recognition_revoke_seconds: float = 0.25,
                  focus_switch_threshold: float = 0.1,
                  focus_switch_seconds: float = 0.5,
+                 focus_min_area_frac: float = 0.0,
+                 focus_dwell_seconds: float = 0.0,
                  emotion_debounce_seconds: float = 0.3,
                  auto_enroll: bool = True,
-                 enroll_min_frames: int = 10):
+                 enroll_min_frames: int = 10,
+                 enroll_min_face_px: int = 0,
+                 enroll_min_sharpness: float = 0.0,
+                 enroll_frontal_tolerance: float = 1.0):
         self.db = db
         self.emotion_detector = emotion_detector
         self.frame_scale = frame_scale
@@ -398,6 +422,10 @@ class FaceTracker:
         self._emotion_debounce_s = emotion_debounce_seconds
         self._auto_enroll = auto_enroll
         self._enroll_min_frames = enroll_min_frames
+        # Enrollment quality gate (0 / 1.0 = disabled, so defaults are a no-op).
+        self._enroll_min_face_px = enroll_min_face_px
+        self._enroll_min_sharpness = enroll_min_sharpness
+        self._enroll_frontal_tolerance = enroll_frontal_tolerance
 
         self._tracks: list[TrackedFace] = []
         self._identities: dict[int, Identity] = {}
@@ -410,6 +438,11 @@ class FaceTracker:
         self._focus_id: Optional[int] = None
         self._focus_switch_threshold = focus_switch_threshold
         self._focus_switch_s = focus_switch_seconds
+        # Engagement gate: a face must cover at least this fraction of the frame
+        # (proximity) and be held for this long before it can take focus. Both
+        # default to off, so background passers-by are filtered only when set.
+        self._focus_min_area_frac = focus_min_area_frac
+        self._focus_dwell_s = focus_dwell_seconds
         self._focus_challenger_id: Optional[int] = None
         self._focus_challenger_since: float = 0.0
 
@@ -643,7 +676,7 @@ class FaceTracker:
         face = self.get_face_by_id(track_id)
         if face is None:
             return False
-        self.db.add_face(person_id, face.encoding, frame, face.bbox)
+        self.db.add_face(person_id, face.last_encoding, frame, face.bbox)
         with self._lock:
             self._identities[track_id] = Identity(
                 person_id=person_id, confidence=100.0,
@@ -681,8 +714,11 @@ class FaceTracker:
             frame = self._last_frames.get(track.track_id)
             if frame is None:
                 continue
+            if not self._passes_enroll_quality(frame, track.bbox):
+                continue
             person_id = self._allocate_person_id()
-            self.db.add_face(person_id, track.encoding, frame, track.bbox)
+            # Enroll the clean raw encoding, not the EMA-smoothed tracking one.
+            self.db.add_face(person_id, track.last_encoding, frame, track.bbox)
             self._identities[track.track_id] = Identity(
                 person_id=person_id, confidence=100.0,
                 _matching_since=0.0, _confirmed=True,
@@ -692,6 +728,62 @@ class FaceTracker:
                 FaceEnrolledPayload(person_id=person_id, bbox=track.bbox),
             ))
         return events
+
+    def _passes_enroll_quality(self, frame, bbox) -> bool:
+        """Quality gate for auto-enrollment: size, sharpness, frontalness.
+
+        Each check is skipped when its threshold is at the disabled sentinel
+        (0 / 1.0), so the default configuration enrolls exactly as before.
+        Only runs on enrollment candidates (rare), so the landmark pass below
+        is not a per-frame cost.
+        """
+        top, right, bottom, left = bbox
+        w, h = right - left, bottom - top
+        if min(w, h) < self._enroll_min_face_px:
+            return False
+
+        if self._enroll_min_sharpness > 0.0:
+            roi = frame[max(0, top):max(0, bottom), max(0, left):max(0, right)]
+            if roi.size == 0:
+                return False
+            gray = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+            if cv2.Laplacian(gray, cv2.CV_64F).var() < self._enroll_min_sharpness:
+                return False
+
+        if self._enroll_frontal_tolerance < 1.0 and not self._is_frontal(frame, bbox):
+            return False
+
+        return True
+
+    def _is_frontal(self, frame, bbox) -> bool:
+        """Cheap yaw proxy: is the nose roughly centred between the eyes?
+
+        Uses dlib landmarks (via face_recognition) on the single enrollment
+        crop. Returns True on any landmark failure so we never *block* on a
+        detector hiccup -- the gate is meant to reject obvious profiles, not
+        to be a hard authority. A true head-pose estimator arrives in the
+        InsightFace phase.
+        """
+        top, right, bottom, left = bbox
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        try:
+            landmarks = face_recognition.face_landmarks(rgb, [(top, right, bottom, left)])
+        except Exception:
+            return True
+        if not landmarks:
+            return False
+        lm = landmarks[0]
+        left_eye, right_eye, nose = lm.get("left_eye"), lm.get("right_eye"), lm.get("nose_tip")
+        if not (left_eye and right_eye and nose):
+            return False
+        lx = np.mean([p[0] for p in left_eye])
+        rx = np.mean([p[0] for p in right_eye])
+        nx = np.mean([p[0] for p in nose])
+        span = rx - lx
+        if abs(span) < 1e-3:
+            return False
+        ratio = (nx - lx) / span  # ~0.5 looking straight ahead
+        return abs(ratio - 0.5) <= self._enroll_frontal_tolerance
 
     @property
     def active_tracks(self) -> list[TrackedFace]:
@@ -709,26 +801,41 @@ class FaceTracker:
             logger.info(f"[{e.type.name}] track={e.track_id} {e.payload}")
             self._dispatcher.dispatch(e)
 
+    def _focus_change_event(self, old_id, new_id, old_score, new_score, new_pid):
+        """Build a FOCUS_CHANGED event. new_id=None means focus was cleared
+        (payload.new_track_id reports 0, matching the historical contract)."""
+        return self._make_event(
+            FaceEventType.FOCUS_CHANGED, new_id,
+            FocusChangedPayload(
+                old_track_id=old_id,
+                new_track_id=new_id if new_id is not None else 0,
+                old_focus_score=old_score, new_focus_score=new_score,
+                new_person_id=new_pid,
+            )
+        )
+
     def _update_focus_scores(self, frame_w, frame_h) -> list[FaceEvent]:
-        """Compute focus scores and return any focus-change events."""
+        """Compute focus scores and return any focus-change events.
+
+        Focus only lands on a face that passes the proximity gate (covers at
+        least ``focus_min_area_frac`` of the frame) and is held for
+        ``focus_dwell_seconds`` -- so background passers-by never trigger it.
+        With both at their disabled defaults this reduces to the original
+        centrality+size selection with switch hysteresis.
+        """
         events = []
         now = time.time()
 
         if not self._tracks:
             if self._focus_id is not None:
-                events.append(self._make_event(
-                    FaceEventType.FOCUS_CHANGED, None,
-                    FocusChangedPayload(
-                        old_track_id=self._focus_id, new_track_id=0,
-                        old_focus_score=0, new_focus_score=0, new_person_id=None,
-                    )
-                ))
+                events.append(self._focus_change_event(self._focus_id, None, 0.0, 0.0, None))
             self._focus_id = None
             self._focus_challenger_id = None
             self._focus_challenger_since = 0.0
             return events
 
         cx, cy = frame_w / 2, frame_h / 2
+        frame_area = max(1, frame_w * frame_h)
         max_area = max(t.area for t in self._tracks) or 1
 
         for track in self._tracks:
@@ -741,37 +848,57 @@ class FaceTracker:
 
         visible = [t for t in self._tracks if t.is_visible]
         if not visible:
-            return events
+            return events  # keep the current focus as a ghost while occluded
 
-        best = max(visible, key=lambda f: f.focus_score)
+        cur = next((t for t in self._tracks if t.track_id == self._focus_id), None)
+        if cur is not None and not cur.is_visible:
+            return events  # focused face briefly occluded -> hold focus
 
-        current_exists = any(t.track_id == self._focus_id for t in self._tracks)
-        if self._focus_id is None or not current_exists:
-            old_id = self._focus_id
-            self._focus_id = best.track_id
+        # Proximity gate: only faces close enough to the camera are eligible.
+        eligible = [t for t in visible
+                    if t.area / frame_area >= self._focus_min_area_frac]
+        if not eligible:
+            # Only distant/background faces remain -> nobody is in focus.
+            if self._focus_id is not None:
+                old_score = cur.focus_score if cur else 0.0
+                events.append(self._focus_change_event(self._focus_id, None, old_score, 0.0, None))
+            self._focus_id = None
             self._focus_challenger_id = None
             self._focus_challenger_since = 0.0
-            if old_id != best.track_id:
-                events.append(self._make_event(
-                    FaceEventType.FOCUS_CHANGED, best.track_id,
-                    FocusChangedPayload(
-                        old_track_id=old_id, new_track_id=best.track_id,
-                        old_focus_score=0, new_focus_score=best.focus_score,
-                        new_person_id=self.get_person_id(best.track_id),
-                    )
-                ))
             return events
 
-        current_visible = any(t.track_id == self._focus_id and t.is_visible for t in self._tracks)
-        if not current_visible:
+        best = max(eligible, key=lambda f: f.focus_score)
+        cur_eligible = cur is not None and cur in eligible
+
+        # --- Acquisition: no valid current focus (none, gone, or now too far) ---
+        if not cur_eligible:
+            old_id = self._focus_id
+            if self._focus_dwell_s <= 0:
+                self._focus_id = best.track_id
+                self._focus_challenger_id = None
+                self._focus_challenger_since = 0.0
+                if old_id != best.track_id:
+                    events.append(self._focus_change_event(
+                        old_id, best.track_id, 0.0, best.focus_score,
+                        self.get_person_id(best.track_id)))
+                return events
+            # Require the candidate to dwell before we engage.
+            if best.track_id == self._focus_challenger_id:
+                if now - self._focus_challenger_since >= self._focus_dwell_s:
+                    self._focus_id = best.track_id
+                    self._focus_challenger_id = None
+                    self._focus_challenger_since = 0.0
+                    if old_id != best.track_id:
+                        events.append(self._focus_change_event(
+                            old_id, best.track_id, 0.0, best.focus_score,
+                            self.get_person_id(best.track_id)))
+            else:
+                self._focus_challenger_id = best.track_id
+                self._focus_challenger_since = now
             return events
 
-        current_score = 0.0
-        for t in visible:
-            if t.track_id == self._focus_id:
-                current_score = t.focus_score
-                break
-
+        # --- Switch hysteresis: a valid current focus exists ---
+        current_score = cur.focus_score if cur else 0.0
         if best.track_id != self._focus_id and \
            best.focus_score > current_score + self._focus_switch_threshold:
             if best.track_id == self._focus_challenger_id:
@@ -780,15 +907,9 @@ class FaceTracker:
                     self._focus_id = best.track_id
                     self._focus_challenger_id = None
                     self._focus_challenger_since = 0.0
-                    events.append(self._make_event(
-                        FaceEventType.FOCUS_CHANGED, best.track_id,
-                        FocusChangedPayload(
-                            old_track_id=old_id, new_track_id=best.track_id,
-                            old_focus_score=current_score,
-                            new_focus_score=best.focus_score,
-                            new_person_id=self.get_person_id(best.track_id),
-                        )
-                    ))
+                    events.append(self._focus_change_event(
+                        old_id, best.track_id, current_score, best.focus_score,
+                        self.get_person_id(best.track_id)))
             else:
                 self._focus_challenger_id = best.track_id
                 self._focus_challenger_since = now
@@ -863,6 +984,7 @@ class FaceTracker:
 
     def _update_track(self, track, encoding, bbox, frame):
         now = time.time()
+        track.last_encoding = encoding
         track.encoding = 0.3 * encoding + 0.7 * track.encoding
         track.bbox = bbox
         track.last_seen = now
@@ -885,7 +1007,8 @@ class FaceTracker:
     def _create_track(self, encoding, bbox, frame):
         now = time.time()
         track = TrackedFace(
-            track_id=self._next_id, encoding=encoding.copy(), bbox=bbox,
+            track_id=self._next_id, encoding=encoding.copy(),
+            last_encoding=encoding.copy(), bbox=bbox,
             first_seen=now, last_seen=now, frames_visible=1,
         )
         self._next_id += 1
@@ -1066,7 +1189,8 @@ def main():
     parser = argparse.ArgumentParser(description="Standalone face tracker")
     parser.add_argument("--db-dir", default="known_faces", help="Face database directory")
     parser.add_argument("--camera", type=int, default=0, help="Camera index")
-    parser.add_argument("--scale", type=float, default=0.5, help="Detection scale factor")
+    parser.add_argument("--scale", type=float, default=None,
+                        help="Detection scale factor (overrides face_config.toml)")
     parser.add_argument("--fps", type=int, default=0, help="Max FPS (0 = unlimited)")
     parser.add_argument("--no-emotion", action="store_true", help="Disable emotion detection")
     parser.add_argument("--no-log-window", action="store_true", help="Disable log window")
@@ -1095,15 +1219,19 @@ def main():
             msg = str(p)[:60]
         log_lines.append((ts, event.type.name, msg))
 
-    face_db = FaceDatabase(db_dir=args.db_dir)
+    from face_config import build_db_kwargs, build_tracker_kwargs
+    face_db = FaceDatabase(db_dir=args.db_dir, **build_db_kwargs())
     face_db.load()
 
     emotion_detector = None
     if not args.no_emotion:
         emotion_detector = EmotionDetector()
 
+    tracker_kwargs = build_tracker_kwargs()
+    if args.scale is not None:
+        tracker_kwargs["frame_scale"] = args.scale
     tracker = FaceTracker(db=face_db, emotion_detector=emotion_detector,
-                          frame_scale=args.scale)
+                          **tracker_kwargs)
     tracker.subscribe(on_event_display)
 
     cap = cv2.VideoCapture(args.camera)

--- a/face/migrate_db.py
+++ b/face/migrate_db.py
@@ -1,0 +1,137 @@
+"""Rebuild the face database for the InsightFace (ArcFace) backend.
+
+The legacy dlib database (``faces.pkl``, 128-d Euclidean) is incompatible with
+the InsightFace backend, which uses 512-d L2-normalized ArcFace embeddings under
+cosine distance. Rather than re-meeting everyone, this tool re-embeds the per-
+person face crops that were saved alongside the old db
+(``known_faces/pXXX/*.jpg``) and writes a fresh v3 cosine db
+(``known_faces/faces_arcface.pkl``).
+
+Usage:
+    uv run python migrate_db.py [--db-dir known_faces] [--det-size 640]
+                                [--det-thresh 0.5] [--dry-run]
+
+The original ``faces.pkl`` is left untouched, so the dlib backend keeps working.
+"""
+
+import argparse
+import logging
+import os
+import re
+
+import cv2
+import numpy as np
+
+from face_tracker import FaceDatabase, InsightFaceBackend
+
+logger = logging.getLogger("migrate_db")
+
+_PERSON_DIR_RE = re.compile(r"^p\d+$")
+_IMAGE_EXTS = (".jpg", ".jpeg", ".png")
+
+
+def _embed_crop(backend: InsightFaceBackend, img: np.ndarray):
+    """Return the ArcFace embedding for the largest face in ``img``, or None.
+
+    Saved crops are tight around the face, which can starve the detector; if the
+    first pass finds nothing, retry once with a reflective border for margin.
+    """
+    for pad in (0.0, 0.3):
+        frame = img
+        if pad > 0.0:
+            h, w = img.shape[:2]
+            m = int(round(max(h, w) * pad))
+            frame = cv2.copyMakeBorder(img, m, m, m, m, cv2.BORDER_REFLECT)
+        locations, encodings = backend.detect(frame)
+        if encodings:
+            # Pick the largest detected face (top, right, bottom, left).
+            def _area(loc):
+                t, r, b, l = loc
+                return (b - t) * (r - l)
+            best = max(range(len(encodings)), key=lambda i: _area(locations[i]))
+            return encodings[best]
+    return None
+
+
+def migrate(db_dir: str, det_size: int, det_thresh: float, dry_run: bool) -> int:
+    if not os.path.isdir(db_dir):
+        logger.error("db-dir %s does not exist", db_dir)
+        return 1
+
+    backend = InsightFaceBackend(det_size=det_size, det_thresh=det_thresh)
+    db = FaceDatabase(db_dir=db_dir, metric="cosine")  # fresh, not loaded
+
+    person_dirs = sorted(
+        d for d in os.listdir(db_dir)
+        if _PERSON_DIR_RE.match(d) and os.path.isdir(os.path.join(db_dir, d))
+    )
+    if not person_dirs:
+        logger.warning("No pNNN person directories under %s -- nothing to migrate.",
+                       db_dir)
+        return 1
+
+    total_people, total_embedded, total_skipped = 0, 0, 0
+    for pid in person_dirs:
+        pdir = os.path.join(db_dir, pid)
+        images = sorted(
+            f for f in os.listdir(pdir)
+            if f.lower().endswith(_IMAGE_EXTS)
+        )
+        embedded = 0
+        for fname in images:
+            path = os.path.join(pdir, fname)
+            img = cv2.imread(path)
+            if img is None:
+                logger.warning("  %s/%s: unreadable, skipping", pid, fname)
+                total_skipped += 1
+                continue
+            enc = _embed_crop(backend, img)
+            if enc is None:
+                logger.warning("  %s/%s: no face detected, skipping", pid, fname)
+                total_skipped += 1
+                continue
+            if not dry_run:
+                db.add_encoding(pid, enc)
+            embedded += 1
+        if embedded:
+            total_people += 1
+            total_embedded += embedded
+            logger.info("%s: %d/%d crops embedded", pid, embedded, len(images))
+        else:
+            logger.warning("%s: no usable crops (%d images)", pid, len(images))
+
+    logger.info("Migrated %d people, %d embeddings (%d crops skipped).",
+                total_people, total_embedded, total_skipped)
+    if dry_run:
+        logger.info("Dry run -- %s not written.", db.db_file)
+        return 0
+    if total_embedded == 0:
+        logger.error("Nothing embedded; refusing to write an empty db.")
+        return 1
+    db.save()
+    logger.info("Wrote %s (schema v%d, cosine).", db.db_file, db.schema_version)
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--db-dir", default="known_faces",
+                        help="Face db directory holding pNNN/ crop folders")
+    parser.add_argument("--det-size", type=int, default=640,
+                        help="InsightFace detector input size (square)")
+    parser.add_argument("--det-thresh", type=float, default=0.5,
+                        help="InsightFace minimum detector confidence")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Embed and report, but do not write the db")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s [%(levelname)s] %(message)s",
+                        datefmt="%H:%M:%S")
+    raise SystemExit(migrate(args.db_dir, args.det_size, args.det_thresh,
+                             args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/face/people_memory.py
+++ b/face/people_memory.py
@@ -716,7 +716,13 @@ def _dedupe_person_facts(
 
 
 def _load_face_encodings_by_person(db_dir: str) -> dict:
-    """Load ``known_faces/faces.pkl`` and return {person_id: [encoding, ...]}."""
+    """Load ``known_faces/faces.pkl`` and return {person_id: [encoding, ...]}.
+
+    NOTE: this reads the legacy dlib db (``faces.pkl``, 128-d, Euclidean) used by
+    the offline ``dedupe``/``similar`` CLIs. The live recognition path now defaults
+    to the InsightFace backend, which writes ``faces_arcface.pkl`` (512-d, cosine);
+    those CLIs and the L2 thresholds in ``main()`` are not yet updated for it.
+    """
     path = os.path.join(db_dir, "faces.pkl")
     if not os.path.exists(path):
         return {}

--- a/face/people_memory.py
+++ b/face/people_memory.py
@@ -715,39 +715,49 @@ def _dedupe_person_facts(
     return kept, changes
 
 
-def _load_face_encodings_by_person(db_dir: str) -> dict:
-    """Load ``known_faces/faces.pkl`` and return {person_id: [encoding, ...]}.
+def _load_face_encodings_by_person(db_dir: str) -> tuple[dict, str]:
+    """Load the face db and return ({person_id: [encoding, ...]}, metric).
 
-    NOTE: this reads the legacy dlib db (``faces.pkl``, 128-d, Euclidean) used by
-    the offline ``dedupe``/``similar`` CLIs. The live recognition path now defaults
-    to the InsightFace backend, which writes ``faces_arcface.pkl`` (512-d, cosine);
-    those CLIs and the L2 thresholds in ``main()`` are not yet updated for it.
+    Prefers the InsightFace db (``faces_arcface.pkl``, 512-d, cosine) and falls
+    back to the legacy dlib db (``faces.pkl``, 128-d, Euclidean); the returned
+    metric tells callers how to compare the encodings. ``({}, "cosine")`` when
+    neither db exists.
     """
-    path = os.path.join(db_dir, "faces.pkl")
-    if not os.path.exists(path):
-        return {}
     import pickle
-    with open(path, "rb") as fh:
-        db = pickle.load(fh)
-    out: dict = {}
-    for pid, enc in zip(db.get("person_ids", []), db.get("encodings", [])):
-        out.setdefault(pid, []).append(enc)
-    return out
+    for fname, metric in (("faces_arcface.pkl", "cosine"), ("faces.pkl", "euclidean")):
+        path = os.path.join(db_dir, fname)
+        if not os.path.exists(path):
+            continue
+        with open(path, "rb") as fh:
+            db = pickle.load(fh)
+        out: dict = {}
+        for pid, enc in zip(db.get("person_ids", []), db.get("encodings", [])):
+            out.setdefault(pid, []).append(enc)
+        return out, metric
+    return {}, "cosine"
 
 
-def _pair_face_distances(encs_a: list, encs_b: list) -> tuple[float, float]:
-    """Return (min, mean) L2 distance between two encoding sets.
+def _pair_face_distances(encs_a: list, encs_b: list,
+                         metric: str = "cosine") -> tuple[float, float]:
+    """Return (min, mean) distance between two encoding sets under ``metric``.
 
-    ``(inf, inf)`` if either set is empty.
+    ``"cosine"`` (``1 - cos``) for L2-normalized ArcFace embeddings, ``"euclidean"``
+    for legacy dlib encodings. ``(inf, inf)`` if either set is empty.
     """
     if not encs_a or not encs_b:
         return float("inf"), float("inf")
     import numpy as _np
-    A = _np.asarray(encs_a)
-    B = _np.asarray(encs_b)
-    # Pairwise L2: ||a-b|| for every a in A, b in B
-    diffs = A[:, None, :] - B[None, :, :]
-    d = _np.linalg.norm(diffs, axis=2)
+    A = _np.asarray(encs_a, dtype=float)
+    B = _np.asarray(encs_b, dtype=float)
+    if metric == "cosine":
+        # Normalize defensively, then cosine distance = 1 - A·B for every pair.
+        A = A / (_np.linalg.norm(A, axis=1, keepdims=True) + 1e-12)
+        B = B / (_np.linalg.norm(B, axis=1, keepdims=True) + 1e-12)
+        d = 1.0 - A @ B.T
+    else:
+        # Pairwise L2: ||a-b|| for every a in A, b in B
+        diffs = A[:, None, :] - B[None, :, :]
+        d = _np.linalg.norm(diffs, axis=2)
     return float(d.min()), float(d.mean())
 
 
@@ -770,13 +780,20 @@ def _facts_similarity(facts_a: list[str], facts_b: list[str]) -> float:
     return _jaccard(toks_a, toks_b)
 
 
-def _similarity_verdict(face_min: float, name: float, facts: float) -> Optional[str]:
-    """Classify a pair. Returns a short label or None to hide."""
-    if face_min < 0.40:
+def _similarity_verdict(face_min: float, name: float, facts: float,
+                        metric: str = "cosine") -> Optional[str]:
+    """Classify a pair. Returns a short label or None to hide.
+
+    Face thresholds depend on the metric: cosine distance for ArcFace embeddings
+    sits on a different scale than dlib's Euclidean, so each gets its own
+    "same / maybe" cutoffs.
+    """
+    same, maybe = (0.30, 0.45) if metric == "cosine" else (0.40, 0.55)
+    if face_min < same:
         return "LIKELY SAME"
-    if face_min < 0.55 and (name > 0.85 or facts > 0.30):
+    if face_min < maybe and (name > 0.85 or facts > 0.30):
         return "LIKELY SAME"
-    if face_min < 0.55:
+    if face_min < maybe:
         return "maybe"
     if name > 0.90:
         return "name collision"
@@ -1007,10 +1024,13 @@ def main():
         if not pids:
             print("No people records.")
             return
-        encs_by_pid = _load_face_encodings_by_person(args.db_dir)
+        encs_by_pid, face_metric = _load_face_encodings_by_person(args.db_dir)
         if not encs_by_pid:
-            print(f"Warning: no face encodings loaded from {args.db_dir}/faces.pkl — "
-                  "falling back to name+facts only.")
+            print(f"Warning: no face encodings found in {args.db_dir} "
+                  "(faces_arcface.pkl / faces.pkl) — falling back to name+facts only.")
+        else:
+            print(f"Comparing faces with {face_metric} distance "
+                  f"({len(encs_by_pid)} people).\n")
 
         def meta(pid):
             s = mem._stored.get(pid, {})
@@ -1029,10 +1049,10 @@ def main():
                     continue
                 name_b, facts_b = meta(pid_b)
                 encs_b = encs_by_pid.get(pid_b, [])
-                face_min, face_mean = _pair_face_distances(encs_a, encs_b)
+                face_min, face_mean = _pair_face_distances(encs_a, encs_b, face_metric)
                 name_sim = _name_similarity(name_a, name_b)
                 facts_sim = _facts_similarity(facts_a, facts_b)
-                verdict = _similarity_verdict(face_min, name_sim, facts_sim)
+                verdict = _similarity_verdict(face_min, name_sim, facts_sim, face_metric)
                 if verdict is None and not args.all:
                     continue
                 shown += 1

--- a/face/pyproject.toml
+++ b/face/pyproject.toml
@@ -15,6 +15,14 @@ dependencies = [
     "opencv-python>=4.13.0,<5",
     "piper-tts",
     "faster-whisper",
+    # InsightFace (SCRFD + ArcFace) is the default face backend. It pulls the
+    # buffalo_l model pack (~300 MB) to ~/.insightface/models on first run --
+    # that download is fetched at runtime and is not covered by uv.lock hashes.
+    "insightface>=1.0.1,<2",
+    # CPU/CoreML onnxruntime. For CUDA on the Nvidia laptop, install
+    # onnxruntime-gpu INSTEAD of this (the two wheels conflict); the provider
+    # selector falls back to CPU/CoreML if CUDA is absent, so this default is
+    # safe on every machine.
     "onnxruntime>=1.23.2,<2",
     "torch",
     "torchaudio",

--- a/face/pyproject.toml
+++ b/face/pyproject.toml
@@ -31,9 +31,6 @@ dependencies = [
     "livekit>=1.1.5,<2",
 ]
 
-[project.scripts]
-face-tracker = "face_tracker:main"
-
 # Run scripts with: uv run python <script>.py
 # e.g. uv run python agent.py --shell
-# Standalone tracker: uv run face-tracker
+# Standalone tracker: uv run python face_tracker.py

--- a/face/test_people_similar.py
+++ b/face/test_people_similar.py
@@ -1,0 +1,83 @@
+"""Logic tests for the face-similarity helpers behind the `similar` CLI.
+
+Covers the metric-aware face comparison used by ``people_memory.py similar``
+after the InsightFace switch: cosine vs Euclidean distance, the per-metric
+verdict thresholds, and the db loader preferring the ArcFace db.
+
+Run:  uv run python test_people_similar.py
+"""
+
+import os
+import pickle
+import tempfile
+
+import numpy as np
+
+from people_memory import (
+    _load_face_encodings_by_person,
+    _pair_face_distances,
+    _similarity_verdict,
+)
+
+
+def _unit(v):
+    v = np.asarray(v, dtype=float)
+    return v / np.linalg.norm(v)
+
+
+def test_pair_distances_metrics():
+    a, b, c = _unit([1, 0, 0]), _unit([1, 0, 0]), _unit([0, 1, 0])
+    # cosine: identical -> 0, orthogonal -> 1
+    assert abs(_pair_face_distances([a], [b], "cosine")[0]) < 1e-9
+    assert abs(_pair_face_distances([a], [c], "cosine")[0] - 1.0) < 1e-9
+    # euclidean matches numpy
+    assert abs(_pair_face_distances([a], [c], "euclidean")[0] - np.sqrt(2)) < 1e-9
+    # min is taken across the cross-product of both sets
+    mn, _ = _pair_face_distances([a, c], [b], "cosine")
+    assert abs(mn) < 1e-9
+    # cosine works even if a stored vector is not unit-norm (defensive normalize)
+    assert abs(_pair_face_distances([3.0 * a], [b], "cosine")[0]) < 1e-9
+    # empty sets -> inf
+    assert _pair_face_distances([], [b], "cosine") == (float("inf"), float("inf"))
+    print("ok: pair distances cosine/euclidean")
+
+
+def test_verdict_thresholds():
+    # cosine cutoffs: same < 0.30, maybe < 0.45
+    assert _similarity_verdict(0.20, 0.0, 0.0, "cosine") == "LIKELY SAME"
+    assert _similarity_verdict(0.40, 0.0, 0.0, "cosine") == "maybe"
+    assert _similarity_verdict(0.40, 0.9, 0.0, "cosine") == "LIKELY SAME"
+    assert _similarity_verdict(0.60, 0.0, 0.0, "cosine") is None
+    # euclidean cutoffs: same < 0.40, maybe < 0.55 (legacy dlib scale)
+    assert _similarity_verdict(0.35, 0.0, 0.0, "euclidean") == "LIKELY SAME"
+    assert _similarity_verdict(0.50, 0.0, 0.0, "euclidean") == "maybe"
+    assert _similarity_verdict(0.60, 0.0, 0.0, "euclidean") is None
+    # a 0.50 cosine pair is below the dlib "maybe" line but not the cosine one
+    assert _similarity_verdict(0.50, 0.0, 0.0, "cosine") is None
+    print("ok: verdict thresholds per metric")
+
+
+def test_loader_prefers_arcface():
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "faces.pkl"), "wb") as f:
+            pickle.dump({"person_ids": ["p1"], "encodings": [np.zeros(128)]}, f)
+        encs, metric = _load_face_encodings_by_person(d)
+        assert metric == "euclidean" and "p1" in encs
+
+        # With both present the ArcFace db wins.
+        with open(os.path.join(d, "faces_arcface.pkl"), "wb") as f:
+            pickle.dump({"person_ids": ["pA", "pA"],
+                         "encodings": [np.zeros(512), np.zeros(512)]}, f)
+        encs, metric = _load_face_encodings_by_person(d)
+        assert metric == "cosine" and len(encs["pA"]) == 2 and "p1" not in encs
+
+    with tempfile.TemporaryDirectory() as empty:
+        assert _load_face_encodings_by_person(empty) == ({}, "cosine")
+    print("ok: loader prefers arcface, reports metric")
+
+
+if __name__ == "__main__":
+    test_pair_distances_metrics()
+    test_verdict_thresholds()
+    test_loader_prefers_arcface()
+    print("\nAll people_memory similar-CLI tests passed.")

--- a/face/test_recognition.py
+++ b/face/test_recognition.py
@@ -1,0 +1,150 @@
+"""Headless logic tests for the cosine (InsightFace/ArcFace) recognition path.
+
+Covers the parts of the Phase (a) backend swap that don't need a camera or the
+model pack: the metric-aware distance helpers, the cosine mean-of-k aggregation
+in FaceDatabase.recognize(), the per-metric db file / schema version, and the
+load() guard that refuses a stale-schema db.
+
+Run:  uv run python test_recognition.py
+"""
+
+import os
+import pickle
+import tempfile
+
+import numpy as np
+
+from face_tracker import (
+    FaceDatabase,
+    _embedding_distances,
+    _pair_distance,
+)
+
+
+def _unit(v) -> np.ndarray:
+    v = np.asarray(v, dtype=np.float64)
+    return v / np.linalg.norm(v)
+
+
+def test_distance_helpers():
+    a = _unit([1.0, 0.0, 0.0])
+    b = _unit([1.0, 0.0, 0.0])
+    c = _unit([0.0, 1.0, 0.0])
+    # cosine distance: identical -> 0, orthogonal -> 1
+    assert abs(_pair_distance(a, b, "cosine")) < 1e-9
+    assert abs(_pair_distance(a, c, "cosine") - 1.0) < 1e-9
+    # euclidean distance matches numpy
+    assert abs(_pair_distance(a, c, "euclidean") - np.sqrt(2)) < 1e-9
+    known = np.stack([b, c])
+    d = _embedding_distances(known, a, "cosine")
+    assert d.shape == (2,)
+    assert abs(d[0]) < 1e-9 and abs(d[1] - 1.0) < 1e-9
+    print("ok: distance helpers")
+
+
+def test_cosine_mean_of_k():
+    with tempfile.TemporaryDirectory() as d:
+        db = FaceDatabase(db_dir=d, tolerance=0.4, recognition_k=2, metric="cosine")
+        # Person A: a tight cluster near +x. Person B: near +y.
+        a_dir = _unit([1.0, 0.05, 0.0])
+        b_dir = _unit([0.0, 1.0, 0.05])
+        for jitter in (0.0, 0.02, 0.04):
+            db.add_encoding("pA", _unit(a_dir + jitter * np.array([0, 0, 1.0])))
+            db.add_encoding("pB", _unit(b_dir + jitter * np.array([1.0, 0, 0])))
+        # A query right on top of A's cluster resolves to pA with high confidence.
+        pid, conf = db.recognize(_unit([1.0, 0.05, 0.0]))
+        assert pid == "pA", pid
+        assert conf > 80.0, conf
+        # A query near B resolves to pB.
+        pid, _ = db.recognize(_unit([0.0, 1.0, 0.05]))
+        assert pid == "pB", pid
+        # An orthogonal query is beyond tolerance -> no match.
+        pid, conf = db.recognize(_unit([0.0, 0.0, 1.0]))
+        assert pid is None and conf == 0.0, (pid, conf)
+        print("ok: cosine mean-of-k recognition")
+
+
+def test_per_metric_file_and_version():
+    with tempfile.TemporaryDirectory() as d:
+        cos = FaceDatabase(db_dir=d, metric="cosine")
+        euc = FaceDatabase(db_dir=d, metric="euclidean")
+        assert cos.db_file.endswith("faces_arcface.pkl"), cos.db_file
+        assert euc.db_file.endswith("faces.pkl"), euc.db_file
+        assert cos.schema_version == 3 and euc.schema_version == 2
+        print("ok: per-metric db file and schema version")
+
+
+def test_load_rejects_stale_schema():
+    with tempfile.TemporaryDirectory() as d:
+        # A v2-looking db written where the cosine backend expects v3.
+        stale = {
+            "encodings": [np.zeros(128)],
+            "person_ids": ["pX"],
+            "last_seen": {},
+            "schema_version": 2,
+        }
+        cos = FaceDatabase(db_dir=d, metric="cosine")
+        with open(cos.db_file, "wb") as f:
+            pickle.dump(stale, f)
+        cos.load()  # should warn and start empty, not import the 128-d vector
+        assert cos.encoding_count == 0, cos.encoding_count
+        assert "pX" not in cos.known_person_ids
+
+        # A correct v3 db round-trips.
+        cos.add_encoding("pA", _unit([1.0, 0.0, 0.0]))
+        cos.save()
+        again = FaceDatabase(db_dir=d, metric="cosine")
+        again.load()
+        assert again.encoding_count == 1
+        assert "pA" in again.known_person_ids
+        print("ok: load rejects stale schema, accepts matching schema")
+
+
+def test_rename_person():
+    with tempfile.TemporaryDirectory() as d:
+        db = FaceDatabase(db_dir=d, tolerance=0.4, recognition_k=3, metric="cosine")
+        a = _unit([1.0, 0.05, 0.0])
+        # p001 auto-enrolled, plus a saved crop folder on disk.
+        for _ in range(2):
+            db.add_encoding("p001", a)
+        os.makedirs(os.path.join(d, "p001"))
+        open(os.path.join(d, "p001", "shot.jpg"), "wb").close()
+        # Rename p001 -> Per: encodings, db, and crop folder all move.
+        moved = db.rename_person("p001", "Per")
+        assert moved == 2, moved
+        assert "p001" not in db.known_person_ids
+        assert "Per" in db.known_person_ids
+        assert not os.path.isdir(os.path.join(d, "p001"))
+        assert os.path.isfile(os.path.join(d, "Per", "shot.jpg"))
+        assert db.recognize(a)[0] == "Per"
+        # Merge case: a second id renamed into the existing one.
+        db.add_encoding("p002", _unit([1.0, 0.06, 0.0]))
+        moved = db.rename_person("p002", "Per")
+        assert moved == 1
+        assert db.known_person_ids == {"Per"}
+        assert db._db["person_ids"].count("Per") == 3
+        # No-op rename.
+        assert db.rename_person("Per", "Per") == 0
+        print("ok: rename_person moves encodings, crops, and merges")
+
+
+def test_ema_renormalization_math():
+    # Mirrors _update_track's cosine branch: an EMA blend of two unit vectors is
+    # not unit-norm and must be renormalized for cosine distance to stay valid.
+    new = _unit([1.0, 0.0, 0.0])
+    old = _unit([0.6, 0.8, 0.0])
+    blended = 0.3 * new + 0.7 * old
+    assert abs(np.linalg.norm(blended) - 1.0) > 1e-3  # not unit before renorm
+    renorm = blended / np.linalg.norm(blended)
+    assert abs(np.linalg.norm(renorm) - 1.0) < 1e-9
+    print("ok: EMA renormalization keeps unit norm")
+
+
+if __name__ == "__main__":
+    test_distance_helpers()
+    test_cosine_mean_of_k()
+    test_per_metric_file_and_version()
+    test_load_rejects_stale_schema()
+    test_rename_person()
+    test_ema_renormalization_math()
+    print("\nAll recognition logic tests passed.")

--- a/face/uv.lock
+++ b/face/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "platform_machine != 's390x'",
+    "platform_machine == 's390x'",
+]
 
 [[package]]
 name = "ag-ui-protocol"
@@ -758,6 +762,7 @@ dependencies = [
     { name = "face-recognition" },
     { name = "face-recognition-models" },
     { name = "faster-whisper" },
+    { name = "insightface" },
     { name = "livekit" },
     { name = "noisereduce" },
     { name = "numpy" },
@@ -778,6 +783,7 @@ requires-dist = [
     { name = "face-recognition", specifier = ">=1.3.0" },
     { name = "face-recognition-models" },
     { name = "faster-whisper" },
+    { name = "insightface", specifier = ">=1.0.1,<2" },
     { name = "livekit", specifier = ">=1.1.5,<2" },
     { name = "noisereduce" },
     { name = "numpy" },
@@ -1253,6 +1259,19 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio"
+version = "2.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
 name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1262,6 +1281,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "insightface"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "onnxruntime" },
+    { name = "opencv-python" },
+    { name = "requests" },
+    { name = "scikit-image" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/77/a1b06d3755fcfb353cdd46a138ec578d9664ee8b53590e73e9edca328928/insightface-1.0.1.tar.gz", hash = "sha256:27af24891bbba470cb3573b366a0fcca8989fc8503c9f8f281e8cba6fd716075", size = 721597, upload-time = "2026-05-23T06:43:00.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/ce/33989427a7fae952e1606d0edee4191f965630f3c74f2166fa776fafd271/insightface-1.0.1-py3-none-any.whl", hash = "sha256:5f373f6fedbdda5cbc59a34ca386a75a2995cdaf6899402590ae9eb4308fc2e8", size = 762241, upload-time = "2026-05-23T06:42:58.253Z" },
 ]
 
 [[package]]
@@ -1534,6 +1572,18 @@ wheels = [
 ]
 
 [[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
 name = "livekit"
 version = "1.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1746,6 +1796,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5c/08/f8fed64eab35ad1ded82f92bf834160302db19f5bbda5a904df7d4dbf3c4/mistralai-2.3.2.tar.gz", hash = "sha256:a02c7e90ac165e8680c849551ff5fe9788e9fc10b7dbe71817443dc63cc5e9c9", size = 394665, upload-time = "2026-04-10T14:05:36.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e0/9f246d18f8fe6e815f7cae88c437c986b342d3ff568607c8e0d53f4710d0/mistralai-2.3.2-py3-none-any.whl", hash = "sha256:dec05f446502289b76add9796d75465c070fc539b3c01d6f7d3297833bb64981", size = 935914, upload-time = "2026-04-10T14:05:37.845Z" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
 ]
 
 [[package]]
@@ -2081,6 +2162,36 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "onnx"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/93/942d2a0f6a70538eea042ce0445c8aefd46559ad153469986f29a743c01c/onnx-1.21.0.tar.gz", hash = "sha256:4d8b67d0aaec5864c87633188b91cc520877477ec0254eda122bef8be43cd764", size = 12074608, upload-time = "2026-03-27T21:33:36.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/ae/cb644ec84c25e63575d9d8790fdcc5d1a11d67d3f62f872edb35fa38d158/onnx-1.21.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:fc2635400fe39ff37ebc4e75342cc54450eadadf39c540ff132c319bf4960095", size = 17965930, upload-time = "2026-03-27T21:32:48.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/eeb5903586645ef8a49b4b7892580438741acc3df91d7a5bd0f3a59ea9cb/onnx-1.21.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9003d5206c01fa2ff4b46311566865d8e493e1a6998d4009ec6de39843f1b59b", size = 17531344, upload-time = "2026-03-27T21:32:50.837Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9261bd580fb8548c9c37b3c6750387eb8f21ea43c63880d37b2c622e1684285", size = 17613697, upload-time = "2026-03-27T21:32:54.222Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1d/391f3c567ae068c8ac4f1d1316bae97c9eb45e702f05975fe0e17ad441f0/onnx-1.21.0-cp312-abi3-win32.whl", hash = "sha256:9ea4e824964082811938a9250451d89c4ec474fe42dd36c038bfa5df31993d1e", size = 16287200, upload-time = "2026-03-27T21:32:57.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a6/5eefbe5b40ea96de95a766bd2e0e751f35bdea2d4b951991ec9afaa69531/onnx-1.21.0-cp312-abi3-win_amd64.whl", hash = "sha256:458d91948ad9a7729a347550553b49ab6939f9af2cddf334e2116e45467dc61f", size = 16441045, upload-time = "2026-03-27T21:33:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c4/0ed8dc037a39113d2a4d66e0005e07751c299c46b993f1ad5c2c35664c20/onnx-1.21.0-cp312-abi3-win_arm64.whl", hash = "sha256:ca14bc4842fccc3187eb538f07eabeb25a779b39388b006db4356c07403a7bbb", size = 16403134, upload-time = "2026-03-27T21:33:03.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/89/0e1a9beb536401e2f45ac88735e123f2735e12fc7b56ff6c11727e097526/onnx-1.21.0-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:257d1d1deb6a652913698f1e3f33ef1ca0aa69174892fe38946d4572d89dd94f", size = 17975430, upload-time = "2026-03-27T21:33:07.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e6dc71a7b3b317265591b20a5f71d0ff5c0d26c24e52283139dc90c66038/onnx-1.21.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7cd7cb8f6459311bdb557cbf6c0ccc6d8ace11c304d1bba0a30b4a4688e245f8", size = 17537435, upload-time = "2026-03-27T21:33:09.765Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/27affcac63eaf2ef183a44fd1a1354b11da64a6c72fe6f3fdcf5571bcee5/onnx-1.21.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b58a4cfec8d9311b73dc083e4c1fa362069267881144c05139b3eba5dc3a840", size = 17617687, upload-time = "2026-03-27T21:33:12.619Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5c/ac8ed15e941593a3672ce424280b764979026317811f2e8508432bfc3429/onnx-1.21.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1a9baf882562c4cebf79589bebb7cd71a20e30b51158cac3e3bbaf27da6163bd", size = 16449402, upload-time = "2026-03-27T21:33:15.555Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/aa/d2231e0dcaad838217afc64c306c8152a080134d2034e247cc973d577674/onnx-1.21.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bba12181566acf49b35875838eba49536a327b2944664b17125577d230c637ad", size = 16408273, upload-time = "2026-03-27T21:33:18.599Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0a/8905b14694def6ad23edf1011fdd581500384062f8c4c567e114be7aa272/onnx-1.21.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:7ee9d8fd6a4874a5fa8b44bbcabea104ce752b20469b88bc50c7dcf9030779ad", size = 17975331, upload-time = "2026-03-27T21:33:21.69Z" },
+    { url = "https://files.pythonhosted.org/packages/61/28/f4e401e5199d1b9c8b76c7e7ae1169e050515258e877b58fa8bb49d3bdcc/onnx-1.21.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5489f25fe461e7f32128218251a466cabbeeaf1eaa791c79daebf1a80d5a2cc9", size = 17537430, upload-time = "2026-03-27T21:33:24.547Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/5d13320eb3660d5af360ea3b43aa9c63a70c92a9b4d1ea0d34501a32fcb8/onnx-1.21.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:db17fc0fec46180b6acbd1d5d8650a04e5527c02b09381da0b5b888d02a204c8", size = 17617662, upload-time = "2026-03-27T21:33:27.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/50/3eaa1878338247be021e6423696813d61e77e534dccbd15a703a144e703d/onnx-1.21.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19d9971a3e52a12968ae6c70fd0f86c349536de0b0c33922ecdbe52d1972fe60", size = 16463688, upload-time = "2026-03-27T21:33:30.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/48/38d46b43bbb525e0b6a4c2c4204cc6795d67e45687a2f7403e06d8e7053d/onnx-1.21.0-cp314-cp314t-win_arm64.whl", hash = "sha256:efba467efb316baf2a9452d892c2f982b9b758c778d23e38c7f44fa211b30bb9", size = 16423387, upload-time = "2026-03-27T21:33:33.446Z" },
 ]
 
 [[package]]
@@ -3112,6 +3223,56 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy" },
+    { name = "tifffile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/48/02357ffb2cca35640f33f2cfe054a4d6d5d7a229b88880a64f1e45c11f4e/scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7", size = 12346329, upload-time = "2025-12-20T17:11:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5", size = 12031726, upload-time = "2025-12-20T17:11:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/9564250dfd65cb20404a611016db52afc6268b2b371cd19c7538ea47580f/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21", size = 13094910, upload-time = "2025-12-20T17:11:16.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b", size = 13660939, upload-time = "2025-12-20T17:11:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d6/91d8973584d4793d4c1a847d388e34ef1218d835eeddecfc9108d735b467/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb", size = 14138938, upload-time = "2025-12-20T17:11:20.919Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9a/7e15d8dc10d6bbf212195fb39bdeb7f226c46dd53f9c63c312e111e2e175/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd", size = 14752243, upload-time = "2025-12-20T17:11:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1", size = 11906770, upload-time = "2025-12-20T17:11:25.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/96941474a18a04b69b6f6562a5bd79bd68049fa3728d3b350976eccb8b93/scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219", size = 11342506, upload-time = "2025-12-20T17:11:27.399Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e5/c1a9962b0cf1952f42d32b4a2e48eed520320dbc4d2ff0b981c6fa508b6b/scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49", size = 12663278, upload-time = "2025-12-20T17:11:29.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/c1a276a59ce8e4e24482d65c1a3940d69c6b3873279193b7ebd04e5ee56b/scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3", size = 12405142, upload-time = "2025-12-20T17:11:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/f1cbd1357caef6c7993f7efd514d6e53d8fd6f7fe01c4714d51614c53289/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604", size = 12942086, upload-time = "2025-12-20T17:11:33.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/74d9fb87c5655bd64cf00b0c44dc3d6206d9002e5f6ba1c9aeb13236f6bf/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37", size = 13265667, upload-time = "2025-12-20T17:11:36.11Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/73/faddc2413ae98d863f6fa2e3e14da4467dd38e788e1c23346cf1a2b06b97/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc", size = 14001966, upload-time = "2025-12-20T17:11:38.55Z" },
+    { url = "https://files.pythonhosted.org/packages/02/94/9f46966fa042b5d57c8cd641045372b4e0df0047dd400e77ea9952674110/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9", size = 14359526, upload-time = "2025-12-20T17:11:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/2840fe38f10057f40b1c9f8fb98a187a370936bf144a4ac23452c5ef1baf/scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a", size = 12287629, upload-time = "2025-12-20T17:11:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ba/73b6ca70796e71f83ab222690e35a79612f0117e5aaf167151b7d46f5f2c/scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e", size = 11647755, upload-time = "2025-12-20T17:11:45.279Z" },
+    { url = "https://files.pythonhosted.org/packages/51/44/6b744f92b37ae2833fd423cce8f806d2368859ec325a699dc30389e090b9/scikit_image-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63af3d3a26125f796f01052052f86806da5b5e54c6abef152edb752683075a9c", size = 12365810, upload-time = "2025-12-20T17:11:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f5/83590d9355191f86ac663420fec741b82cc547a4afe7c4c1d986bf46e4db/scikit_image-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ce00600cd70d4562ed59f80523e18cdcc1fae0e10676498a01f73c255774aefd", size = 12075717, upload-time = "2025-12-20T17:11:49.483Z" },
+    { url = "https://files.pythonhosted.org/packages/72/48/253e7cf5aee6190459fe136c614e2cbccc562deceb4af96e0863f1b8ee29/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6381edf972b32e4f54085449afde64365a57316637496c1325a736987083e2ab", size = 13161520, upload-time = "2025-12-20T17:11:51.58Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c3/cec6a3cbaadfdcc02bd6ff02f3abfe09eaa7f4d4e0a525a1e3a3f4bce49c/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6624a76c6085218248154cc7e1500e6b488edcd9499004dd0d35040607d7505", size = 13684340, upload-time = "2025-12-20T17:11:53.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0d/39a776f675d24164b3a267aa0db9f677a4cb20127660d8bf4fd7fef66817/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f775f0e420faac9c2aa6757135f4eb468fb7b70e0b67fa77a5e79be3c30ee331", size = 14203839, upload-time = "2025-12-20T17:11:55.89Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/25/2514df226bbcedfe9b2caafa1ba7bc87231a0c339066981b182b08340e06/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede4d6d255cc5da9faeb2f9ba7fedbc990abbc652db429f40a16b22e770bb578", size = 14770021, upload-time = "2025-12-20T17:11:58.014Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5b/0671dc91c0c79340c3fe202f0549c7d3681eb7640fe34ab68a5f090a7c7f/scikit_image-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0660b83968c15293fd9135e8d860053ee19500d52bf55ca4fb09de595a1af650", size = 12023490, upload-time = "2025-12-20T17:12:00.013Z" },
+    { url = "https://files.pythonhosted.org/packages/65/08/7c4cb59f91721f3de07719085212a0b3962e3e3f2d1818cbac4eeb1ea53e/scikit_image-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:b8d14d3181c21c11170477a42542c1addc7072a90b986675a71266ad17abc37f", size = 11473782, upload-time = "2025-12-20T17:12:01.983Z" },
+    { url = "https://files.pythonhosted.org/packages/49/41/65c4258137acef3d73cb561ac55512eacd7b30bb4f4a11474cad526bc5db/scikit_image-0.26.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cde0bbd57e6795eba83cb10f71a677f7239271121dc950bc060482834a668ad1", size = 12686060, upload-time = "2025-12-20T17:12:03.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/32/76971f8727b87f1420a962406388a50e26667c31756126444baf6668f559/scikit_image-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:163e9afb5b879562b9aeda0dd45208a35316f26cc7a3aed54fd601604e5cf46f", size = 12422628, upload-time = "2025-12-20T17:12:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0d/996febd39f757c40ee7b01cdb861867327e5c8e5f595a634e8201462d958/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724f79fd9b6cb6f4a37864fe09f81f9f5d5b9646b6868109e1b100d1a7019e59", size = 12962369, upload-time = "2025-12-20T17:12:07.912Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b4/612d354f946c9600e7dea012723c11d47e8d455384e530f6daaaeb9bf62c/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3268f13310e6857508bd87202620df996199a016a1d281b309441d227c822394", size = 13272431, upload-time = "2025-12-20T17:12:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/26c00b466e06055a086de2c6e2145fe189ccdc9a1d11ccc7de020f2591ad/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fac96a1f9b06cd771cbbb3cd96c5332f36d4efd839b1d8b053f79e5887acde62", size = 14016362, upload-time = "2025-12-20T17:12:12.793Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/00a90402e1775634043c2a0af8a3c76ad450866d9fa444efcc43b553ba2d/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c1e7bd342f43e7a97e571b3f03ba4c1293ea1a35c3f13f41efdc8a81c1dc8f2", size = 14364151, upload-time = "2025-12-20T17:12:14.909Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ca/918d8d306bd43beacff3b835c6d96fac0ae64c0857092f068b88db531a7c/scikit_image-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b702c3bb115e1dcf4abf5297429b5c90f2189655888cbed14921f3d26f81d3a4", size = 12413484, upload-time = "2025-12-20T17:12:17.046Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cd/4da01329b5a8d47ff7ec3c99a2b02465a8017b186027590dc7425cee0b56/scikit_image-0.26.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0608aa4a9ec39e0843de10d60edb2785a30c1c47819b67866dd223ebd149acaf", size = 11769501, upload-time = "2025-12-20T17:12:19.339Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3290,6 +3451,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl", hash = "sha256:0d7382d2769b855b81ce358528e2b40c16d48aa39031746efa81215205332a8d", size = 267108, upload-time = "2026-05-31T23:57:10.597Z" },
 ]
 
 [[package]]

--- a/mcpclient_speech/eyewindow.py
+++ b/mcpclient_speech/eyewindow.py
@@ -65,12 +65,7 @@ class EyeWindow:
         self.txt1 = CCText(self.win.fig, (0.5, 0.45), "", 1.0/20)
         self.txt2 = CCText(self.win.fig, (0.5, 0.38), "", 1.0/40)
         self.txt_indicator = CCText(self.win.fig, (0.05, 0.95), "", 1.0/40)
-        self.cam_ax = self.win.fig.add_axes((0.78, 0.80, 0.20, 0.18))
-        self.cam_ax.set_xticks([]); self.cam_ax.set_yticks([])
-        for s in self.cam_ax.spines.values():
-            s.set_visible(False)
-        self.cam_im = self.cam_ax.imshow(np.zeros((2, 2, 3), dtype=np.uint8))
-        self._pending_frame = None
+        self.camwin = None
         self.win.set_background(self.bg)
         self.win.register_target((0.15, 0.1, 0.7, 0.7), self)
         self.win.add_resize_callback(self.resize)
@@ -111,6 +106,9 @@ class EyeWindow:
     def set_indicator(self, text):
         self.txt_indicator.text.set_text(text or "")
 
+    def attach_camera_window(self, camwin):
+        self.camwin = camwin
+
     def key_press_event(self, event):
         if event.key == "control":
             if self.func1:
@@ -134,6 +132,67 @@ class EyeWindow:
         if self.func2:
             self.func2(event, self.obj)
 
+    def check_events(self):
+        if self.camwin is not None:
+            self.camwin.check_events()
+        self.win.fig.canvas.flush_events()
+
+
+class CameraWindow:
+    """A standalone window showing the annotated camera/face image.
+
+    Mirrors the parts of EyeWindow that WindowMgr dispatches events to
+    (key_press_event / key_release_event / exit_event) so keyboard shortcuts
+    and close-to-quit behave the same regardless of which window has focus.
+    The keydict is shared (same object) with the EyeWindow.
+    """
+
+    def __init__(self, name, width=640, height=480, keydict=None):
+        self.width = width
+        self.height = height
+        self.win = WindowMgr(name, width, height, 1, 1)
+        self.bg = gray(0.5)
+        self.win.set_background(self.bg)
+        self.cam_ax = self.win.fig.add_axes((0.0, 0.0, 1.0, 1.0))
+        self.cam_ax.set_xticks([]); self.cam_ax.set_yticks([])
+        for s in self.cam_ax.spines.values():
+            s.set_visible(False)
+        self.cam_im = self.cam_ax.imshow(np.zeros((2, 2, 3), dtype=np.uint8))
+        self._pending_frame = None
+        self._frame_shape = None
+        self._sized = False
+        self.keydict = keydict if keydict is not None else {}
+        self.func1 = None
+        self.func2 = None
+        self.obj = None
+        self.exitfunc = None
+        self.exitobj = None
+        self.win.register_target((0.0, 0.0, 1.0, 1.0), self)
+        self.win.add_close_callback(self.exit_event)
+        self.win.fig.canvas.draw()
+
+    def set_exit_callback(self, func, obj):
+        self.exitfunc = func
+        self.exitobj = obj
+
+    def exit_event(self, ev):
+        if self.exitfunc:
+            self.exitfunc(self.exitobj)
+
+    def key_press_event(self, event):
+        if event.key == "control":
+            if self.func1:
+                self.func1(event, self.obj)
+        elif event.key in self.keydict and self.keydict[event.key]:
+            self.keydict[event.key][0](event, self.keydict[event.key][1])
+        else:
+            print("Press", event.key)
+
+    def key_release_event(self, event):
+        if event.key == "control":
+            if self.func2:
+                self.func2(event, self.obj)
+
     def set_camera_frame(self, frame_rgb):
         self._pending_frame = frame_rgb
 
@@ -141,11 +200,23 @@ class EyeWindow:
         frame = self._pending_frame
         if frame is not None:
             self._pending_frame = None
+            shape = frame.shape[:2]
+            if shape != self._frame_shape:
+                self._frame_shape = shape
+                # set_extent updates the image's drawn region in data coords
+                # AND set_xlim/set_ylim accordingly; set_data alone does not
+                # touch the extent stored at imshow() time, so the new frame
+                # would be rendered into the old 2-pixel placeholder region.
+                self.cam_im.set_extent((-0.5, frame.shape[1] - 0.5,
+                                        frame.shape[0] - 0.5, -0.5))
+                if not self._sized:
+                    self._sized = True
+                    h, w = shape
+                    scale = 640.0 / max(w, h)
+                    dpi = self.win.fig.dpi
+                    self.win.fig.set_size_inches((w * scale / dpi,
+                                                  h * scale / dpi))
             self.cam_im.set_data(frame)
-            if frame.shape[:2] != self.cam_im.get_array().shape[:2]:
-                self.cam_ax.set_xlim(-0.5, frame.shape[1] - 0.5)
-                self.cam_ax.set_ylim(frame.shape[0] - 0.5, -0.5)
-            self.cam_ax.draw_artist(self.cam_im)
-            self.win.fig.canvas.blit(self.cam_ax.bbox)
+            self.win.fig.canvas.draw()
         self.win.fig.canvas.flush_events()
 

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -32,6 +32,7 @@ from voice_output import VoiceOutput
 from face_tracker import (
     FaceTracker, FaceDatabase, FaceEventType,
 )
+from face_config import build_db_kwargs, build_tracker_kwargs
 import cv2
 from config import load_config
 from interaction_logger import InteractionLogger
@@ -134,6 +135,24 @@ def parse_args():
     parser.add_argument('--mic', type=int, default=None, help='Microphone device index (default: system default)')
     parser.add_argument('-v', '--verbose', action='count', default=0, help='Increase verbosity (-v for INFO, -vv for DEBUG)')
     parser.add_argument('--config', default=None, help='Path to config TOML file (default: config.toml next to this script)')
+
+    # Face-tracker tuning. Each overrides the matching key in
+    # face/face_config.toml [tracker]; left unset, the config value (then the
+    # face_tracker.py default) applies.
+    tune = parser.add_argument_group('face tracker tuning')
+    tune.add_argument('--frame-scale', type=float, default=None,
+                      help='Detection downscale factor (higher = better on distant faces, more CPU)')
+    tune.add_argument('--recognition-tolerance', type=float, default=None,
+                      help='Max embedding distance to accept a match (lower = stricter)')
+    tune.add_argument('--recognition-k', type=int, default=None,
+                      help='Average the k nearest stored samples per person when matching')
+    tune.add_argument('--max-missing-seconds', type=float, default=None,
+                      help='Grace period before a missing face is dropped (survives look-aways)')
+    tune.add_argument('--focus-min-area-frac', type=float, default=None,
+                      help='Min fraction of frame a face must cover to take focus (0 = off)')
+    tune.add_argument('--focus-dwell-seconds', type=float, default=None,
+                      help='Seconds a candidate must be held before it takes focus (0 = off)')
+
     log_group = parser.add_mutually_exclusive_group()
     log_group.add_argument('--log-file', default=None, help='Log every interaction event to this JSONL file (overwrites on each run)')
     log_group.add_argument('--log-dir', default=None, help='Log every interaction event to a new timestamped JSONL file in this directory')
@@ -607,9 +626,26 @@ async def main(args):
             return False
 
         ### Initialize the face_tracker here, with on_face_change as callback
-        face_db = FaceDatabase()
+        # Tuning comes from face/face_config.toml [tracker]; CLI flags override.
+        db_kwargs = build_db_kwargs()
+        if args.recognition_tolerance is not None:
+            db_kwargs["tolerance"] = args.recognition_tolerance
+        if args.recognition_k is not None:
+            db_kwargs["recognition_k"] = args.recognition_k
+
+        tracker_kwargs = build_tracker_kwargs()
+        for cli_val, kw in (
+            (args.frame_scale, "frame_scale"),
+            (args.max_missing_seconds, "max_missing_seconds"),
+            (args.focus_min_area_frac, "focus_min_area_frac"),
+            (args.focus_dwell_seconds, "focus_dwell_seconds"),
+        ):
+            if cli_val is not None:
+                tracker_kwargs[kw] = cli_val
+
+        face_db = FaceDatabase(**db_kwargs)
         face_db.load()
-        tracker = FaceTracker(db=face_db, emotion_detector=None)
+        tracker = FaceTracker(db=face_db, emotion_detector=None, **tracker_kwargs)
 
         focus_state = {"track_id": None, "person_id": None}
 

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -89,6 +89,7 @@ curr_person = None
 curr_prompt = ""
 
 win: EyeWindow | None = None
+cam_win: CameraWindow | None = None
 voice_in: VoiceInput | None = None
 voice_out: VoiceOutput | None = None
 listener: ContinuousListener | None = None
@@ -219,6 +220,8 @@ def kp_save_recording(_event, _obj):
     logger.info("Save-next-recordings count is now %d", pending)
 
 def on_exit(state):
+    if state.get('newstate') == 'exit':
+        return
     logger.info("Exit event")
     _ilog("state_change", **{"from": state.get('currstate'), "to": "exit"})
     state['evtime'] = time.time()
@@ -477,6 +480,7 @@ async def main(args):
     global messages
     global tools
     global win
+    global cam_win
     global model
     global has_sysprompt
     global has_sysprompt_lang
@@ -554,6 +558,9 @@ async def main(args):
         win.keydict["m"] = (kp_toggle_mute, None)
         win.keydict[" "] = (kp_force_process, None)
         win.keydict["s"] = (kp_save_recording, None)
+        cam_win = CameraWindow(name + " - Camera", keydict=win.keydict)
+        cam_win.set_exit_callback(on_exit, state)
+        win.attach_camera_window(cam_win)
         win.check_events()
         print('Created the interaction window')
 
@@ -664,7 +671,9 @@ async def main(args):
                         cv2.putText(frame, label, (left + 4, bottom + 16),
                                     cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 0), 1)
                     rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                    win.set_camera_frame(rgb)
+                    cam_win.set_camera_frame(rgb)
+            except Exception:
+                logger.exception("camera_loop crashed")
             finally:
                 cap.release()
 

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -32,7 +32,7 @@ from voice_output import VoiceOutput
 from face_tracker import (
     FaceTracker, FaceDatabase, FaceEventType,
 )
-from face_config import build_db_kwargs, build_tracker_kwargs
+from face_config import build_db_kwargs, build_tracker_kwargs, backend_metric
 import cv2
 from config import load_config
 from interaction_logger import InteractionLogger
@@ -140,8 +140,14 @@ def parse_args():
     # face/face_config.toml [tracker]; left unset, the config value (then the
     # face_tracker.py default) applies.
     tune = parser.add_argument_group('face tracker tuning')
+    tune.add_argument('--backend', choices=['insightface', 'dlib'], default=None,
+                      help='Face detection/embedding backend (default from config: insightface)')
+    tune.add_argument('--det-size', type=int, default=None,
+                      help='InsightFace detector input size (square); larger = better on distant faces, slower')
+    tune.add_argument('--det-thresh', type=float, default=None,
+                      help='InsightFace minimum detector confidence')
     tune.add_argument('--frame-scale', type=float, default=None,
-                      help='Detection downscale factor (higher = better on distant faces, more CPU)')
+                      help='dlib backend detection downscale factor (higher = better on distant faces, more CPU)')
     tune.add_argument('--recognition-tolerance', type=float, default=None,
                       help='Max embedding distance to accept a match (lower = stricter)')
     tune.add_argument('--recognition-k', type=int, default=None,
@@ -632,9 +638,16 @@ async def main(args):
             db_kwargs["tolerance"] = args.recognition_tolerance
         if args.recognition_k is not None:
             db_kwargs["recognition_k"] = args.recognition_k
+        if args.backend is not None:
+            # Keep the db's metric/file in step with a CLI backend override so
+            # load() opens the matching db (it runs before the tracker is built).
+            db_kwargs["metric"] = backend_metric(args.backend)
 
         tracker_kwargs = build_tracker_kwargs()
         for cli_val, kw in (
+            (args.backend, "backend"),
+            (args.det_size, "det_size"),
+            (args.det_thresh, "det_thresh"),
             (args.frame_scale, "frame_scale"),
             (args.max_missing_seconds, "max_missing_seconds"),
             (args.focus_min_area_frac, "focus_min_area_frac"),

--- a/mcpclient_speech/mcpclient_speech_face.py
+++ b/mcpclient_speech/mcpclient_speech_face.py
@@ -30,7 +30,7 @@ from eyewindow import *
 from voice_input import VoiceInput, ContinuousListener, VoiceEventType, list_input_devices
 from voice_output import VoiceOutput
 from face_tracker import (
-    FaceTracker, FaceDatabase, EmotionDetector, FaceEventType,
+    FaceTracker, FaceDatabase, FaceEventType,
 )
 import cv2
 from config import load_config
@@ -609,8 +609,7 @@ async def main(args):
         ### Initialize the face_tracker here, with on_face_change as callback
         face_db = FaceDatabase()
         face_db.load()
-        emotion_detector = EmotionDetector()
-        tracker = FaceTracker(db=face_db, emotion_detector=emotion_detector)
+        tracker = FaceTracker(db=face_db, emotion_detector=None)
 
         focus_state = {"track_id": None, "person_id": None}
 
@@ -665,8 +664,6 @@ async def main(args):
                             label += f" {pid}"
                         if is_focus:
                             label += " [FOCUS]"
-                        if face.emotion and face.emotion != "neutral":
-                            label += f" {face.emotion}"
                         cv2.rectangle(frame, (left, bottom), (right, bottom + 22), color[::-1], cv2.FILLED)
                         cv2.putText(frame, label, (left + 4, bottom + 16),
                                     cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 0), 1)


### PR DESCRIPTION
The offline `similar` command (find probable duplicate person records by face/name/facts) still read the legacy dlib db (faces.pkl, 128-d) with Euclidean thresholds, so it compared nothing useful on a migrated machine. It now prefers the InsightFace db (faces_arcface.pkl, 512-d), compares with cosine distance, and uses per-metric thresholds — falling back to dlib if that's all that's present.

Depends on #22.